### PR TITLE
feat: add `config` and `configResolved`

### DIFF
--- a/.changeset/moody-rice-work.md
+++ b/.changeset/moody-rice-work.md
@@ -1,0 +1,6 @@
+---
+"rollipop": patch
+"@rollipop/core": patch
+---
+
+add `config` and `configResolved` for plugins

--- a/example/plugins.ts
+++ b/example/plugins.ts
@@ -58,3 +58,14 @@ export function worklet(): Plugin {
     },
   });
 }
+
+export function config(): Plugin {
+  return {
+    name: 'config',
+    configResolved(resolvedConfig) {
+      if (process.env.SHOW_CONFIG === '1') {
+        console.log(resolvedConfig);
+      }
+    },
+  };
+}

--- a/example/rollipop.config.ts
+++ b/example/rollipop.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from 'rollipop';
 
-import { worklet } from './plugins';
+import { config, worklet } from './plugins';
 
 export default defineConfig({
   entry: 'index.js',
-  plugins: [worklet()],
+  plugins: [worklet(), config()],
 });

--- a/packages/core/src/config/__test__/load-config.spec.ts
+++ b/packages/core/src/config/__test__/load-config.spec.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vitest } from 'vitest';
+
+import type { Plugin } from '../../core/plugins/types';
+import type { ResolvedConfig } from '../defaults';
+import { invokePluginConfigResolved, resolvePluginConfig } from '../load-config';
+import type { Config } from '../types';
+
+describe('resolvePluginConfig', () => {
+  it('should resolve plugin config', async () => {
+    const baseConfig: Config = {
+      root: '/foo',
+      resolver: {
+        sourceExtensions: ['ts', 'tsx'],
+        assetExtensions: ['png', 'jpg'],
+        preferNativePlatform: true,
+      },
+      transformer: {
+        define: {
+          __DEV__: 'true',
+        },
+      },
+      serializer: {
+        prelude: ['/path/to/prelude.js'],
+        polyfills: [
+          {
+            type: 'iife',
+            code: 'console.log("polyfill")',
+          },
+        ],
+      },
+      reactNative: {
+        assetRegistryPath: '/path/to/AssetRegistry.js',
+      },
+    };
+
+    const pluginA: Plugin = {
+      name: 'plugin-a',
+      config: {
+        root: '/plugin-a',
+        resolver: {
+          sourceExtensions: ['js', 'jsx'],
+        },
+        transformer: {
+          define: {
+            'process.env.PLUGIN_A': 'true',
+          },
+        },
+        serializer: {
+          prelude: ['/path/to/prelude-plugin-a.js'],
+          polyfills: [
+            {
+              type: 'iife',
+              code: 'console.log("polyfill-plugin-a")',
+            },
+          ],
+        },
+      },
+    };
+
+    const pluginB: Plugin = {
+      name: 'plugin-b',
+      config: () => ({
+        root: '/plugin-b',
+        resolver: {
+          assetExtensions: ['webp'],
+          preferNativePlatform: false,
+        },
+        transformer: {
+          define: {
+            'process.env.PLUGIN_B': 'true',
+          },
+        },
+        serializer: {
+          prelude: ['/path/to/prelude-plugin-b.js'],
+          polyfills: [
+            {
+              type: 'iife',
+              code: 'console.log("polyfill-plugin-b")',
+            },
+          ],
+        },
+        reactNative: {
+          assetRegistryPath: '/path/to/AssetRegistry-plugin-b.js',
+        },
+      }),
+    };
+
+    const pluginC: Plugin = {
+      name: 'plugin-c',
+      config: (config) => {
+        config.root = '/plugin-c';
+
+        if (config.reactNative) {
+          config.reactNative.assetRegistryPath = '/path/to/AssetRegistry-plugin-c.js';
+        }
+      },
+    };
+
+    const pluginConfig = await resolvePluginConfig(baseConfig, [pluginA, pluginB, pluginC]);
+
+    expect(pluginConfig).toEqual({
+      root: '/plugin-c',
+      resolver: {
+        sourceExtensions: ['ts', 'tsx', 'js', 'jsx'],
+        assetExtensions: ['png', 'jpg', 'webp'],
+        preferNativePlatform: false,
+      },
+      transformer: {
+        define: {
+          __DEV__: 'true',
+          'process.env.PLUGIN_A': 'true',
+          'process.env.PLUGIN_B': 'true',
+        },
+      },
+      serializer: {
+        prelude: [
+          '/path/to/prelude.js',
+          '/path/to/prelude-plugin-a.js',
+          '/path/to/prelude-plugin-b.js',
+        ],
+        polyfills: [
+          {
+            type: 'iife',
+            code: 'console.log("polyfill")',
+          },
+          {
+            type: 'iife',
+            code: 'console.log("polyfill-plugin-a")',
+          },
+          {
+            type: 'iife',
+            code: 'console.log("polyfill-plugin-b")',
+          },
+        ],
+      },
+      reactNative: {
+        assetRegistryPath: '/path/to/AssetRegistry-plugin-c.js',
+      },
+    });
+  });
+});
+
+describe('invokePluginConfigResolved', () => {
+  it('should invoke plugin config resolved', async () => {
+    const resolvedConfig = {
+      root: '/root',
+    } as ResolvedConfig;
+
+    const invoked = vitest.fn();
+    const pluginA: Plugin = {
+      name: 'plugin-a',
+      configResolved: (config) => {
+        invoked(config);
+      },
+    };
+
+    const pluginB: Plugin = {
+      name: 'plugin-b',
+      configResolved: async (config) => {
+        invoked(config);
+      },
+    };
+
+    await invokePluginConfigResolved(resolvedConfig, [pluginA, pluginB]);
+
+    expect(invoked).toHaveBeenCalledTimes(2);
+    expect(invoked).toHaveBeenNthCalledWith(1, resolvedConfig);
+    expect(invoked).toHaveBeenNthCalledWith(2, resolvedConfig);
+  });
+});

--- a/packages/core/src/config/__test__/merge-config.spec.ts
+++ b/packages/core/src/config/__test__/merge-config.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+
+import { mergeConfig } from '../merge-config';
+import type { Config } from '../types';
+
+describe('mergeConfig', () => {
+  it('should merge configs', () => {
+    const reporterA = { update: () => {} };
+    const baseConfig: Config = {
+      root: '/foo',
+      resolver: {
+        sourceExtensions: ['ts', 'tsx'],
+        assetExtensions: ['png', 'jpg'],
+        preferNativePlatform: true,
+      },
+      transformer: {
+        define: {
+          __DEV__: 'true',
+        },
+      },
+      serializer: {
+        prelude: ['/path/to/prelude-a.js'],
+        polyfills: [
+          {
+            type: 'iife',
+            code: 'console.log("polyfill-a")',
+          },
+        ],
+      },
+      reactNative: {
+        assetRegistryPath: '/path/to/AssetRegistry.js',
+      },
+      reporter: reporterA,
+    };
+
+    const configA: Config = {
+      root: '/bar',
+      resolver: {
+        sourceExtensions: ['js', 'jsx'],
+      },
+    };
+
+    const reporterB = { update: () => {} };
+    const configB: Config = {
+      root: '/baz',
+      resolver: {
+        // Duplicate source extensions should be removed
+        sourceExtensions: ['ts', 'jsx'],
+      },
+      transformer: {
+        define: {
+          __DEV__: 'false',
+          'process.env.NODE_ENV': 'production',
+        },
+      },
+      serializer: {
+        prelude: ['/path/to/prelude-b.js'],
+        polyfills: [
+          {
+            type: 'iife',
+            code: 'console.log("polyfill-b")',
+          },
+        ],
+      },
+      reporter: reporterB,
+    };
+
+    const config = mergeConfig(baseConfig, configA, configB);
+
+    expect(config).toEqual({
+      root: '/baz',
+      resolver: {
+        sourceExtensions: ['ts', 'tsx', 'js', 'jsx'],
+        assetExtensions: ['png', 'jpg'],
+        preferNativePlatform: true,
+      },
+      transformer: {
+        define: {
+          __DEV__: 'false',
+          'process.env.NODE_ENV': 'production',
+        },
+      },
+      serializer: {
+        prelude: ['/path/to/prelude-a.js', '/path/to/prelude-b.js'],
+        polyfills: [
+          {
+            type: 'iife',
+            code: 'console.log("polyfill-a")',
+          },
+          {
+            type: 'iife',
+            code: 'console.log("polyfill-b")',
+          },
+        ],
+      },
+      reactNative: {
+        assetRegistryPath: '/path/to/AssetRegistry.js',
+      },
+      reporter: reporterB,
+    });
+  });
+});

--- a/packages/core/src/config/merge-config.ts
+++ b/packages/core/src/config/merge-config.ts
@@ -3,10 +3,28 @@ import { mergeWith } from 'es-toolkit';
 import type { DefaultConfig, ResolvedConfig } from './defaults';
 import type { Config } from './types';
 
-export function mergeConfig(baseConfig: DefaultConfig, overrideConfig: Config): ResolvedConfig {
-  return mergeWith(baseConfig, overrideConfig, (target, source, key) => {
-    if (key === 'reporter') {
-      return source.reporter ?? target.reporter;
-    }
-  });
+export function mergeConfig(baseConfig: Config, ...overrideConfigs: Config[]): Config;
+export function mergeConfig(
+  baseConfig: DefaultConfig,
+  ...overrideConfigs: Config[]
+): ResolvedConfig;
+export function mergeConfig(
+  baseConfig: Config | DefaultConfig,
+  ...overrideConfigs: Config[]
+): Config | ResolvedConfig {
+  let mergedConfig = baseConfig;
+
+  for (const overrideConfig of overrideConfigs) {
+    mergedConfig = mergeWith(mergedConfig, overrideConfig, (target, source, key) => {
+      if (['sourceExtensions', 'assetExtensions', 'polyfills', 'prelude'].includes(key)) {
+        return Array.from(new Set([...(target ?? []), ...(source ?? [])]));
+      }
+
+      if (key === 'reporter') {
+        return source ?? target;
+      }
+    });
+  }
+
+  return mergedConfig;
 }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1,6 +1,7 @@
 import type * as rolldown from 'rolldown';
 import type { DevWatchOptions, TransformOptions } from 'rolldown/experimental';
 
+import type { Plugin } from '../core/plugins/types';
 import type { Reporter } from '../types';
 
 export interface Config {
@@ -43,7 +44,7 @@ export interface Config {
   /**
    * Plugins.
    */
-  plugins?: rolldown.Plugin[];
+  plugins?: Plugin[];
   /**
    * Rollipop provides default options for Rolldown, but you can override them by this option.
    *
@@ -76,7 +77,7 @@ export type ResolverConfig = Omit<NonNullable<rolldown.InputOptions['resolve']>,
   preferNativePlatform?: boolean;
 };
 
-export type TransformerConfig = Omit<TransformOptions, 'plugins'> & {
+export type TransformerConfig = Omit<TransformOptions, 'cwd' | 'plugins'> & {
   /**
    * Transform SVG assets files to React components using `@svgr/core`.
    *

--- a/packages/core/src/core/plugins/types.ts
+++ b/packages/core/src/core/plugins/types.ts
@@ -1,0 +1,13 @@
+import type * as rolldown from 'rolldown';
+
+import type { Config, ResolvedConfig } from '../../config';
+
+export type PluginConfig = Omit<Config, 'plugins' | 'dangerously_overrideRolldownOptions'>;
+
+export type Plugin = rolldown.Plugin & {
+  config?:
+    | PluginConfig
+    | ((config: PluginConfig) => PluginConfig | null | void)
+    | ((config: PluginConfig) => Promise<PluginConfig | null | void>);
+  configResolved?: (config: ResolvedConfig) => void | Promise<void>;
+};

--- a/packages/core/src/core/rolldown.ts
+++ b/packages/core/src/core/rolldown.ts
@@ -64,6 +64,7 @@ export async function resolveRolldownOptions(
 
   const mergedTransformOptions = merge(
     {
+      cwd: config.root,
       target: 'es2015',
       jsx: {
         runtime: 'automatic',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export type * from './core/types';
 // Plugins
 export * as plugins from './core/plugins';
 export { PluginUtils } from './core/plugins/utils';
+export type { Plugin, PluginConfig } from './core/plugins/types';
 
 // Assets
 export * as AssetUtils from './core/assets';

--- a/packages/rollipop/src/index.ts
+++ b/packages/rollipop/src/index.ts
@@ -37,6 +37,7 @@ export {
   type TerminalConfig,
   type RolldownConfig,
   type BuildOptions,
+  type Plugin,
   type Reporter,
   type ReportableEvent,
 } from '@rollipop/core';
@@ -48,6 +49,3 @@ export {
   type ServerOptions,
   type DevServer,
 } from '@rollipop/dev-server';
-
-// Re-export `rolldown`
-export type { Plugin } from 'rolldown';


### PR DESCRIPTION
# Description

Similar to [Vite Specific Hooks](https://vite.dev/guide/api-plugin#vite-specific-hooks), `config` and `configResolved` options are now provided.

Plugins can now manipulate the rollipop configuration and check the final resolved configuration that will be applied to the bundler.

```ts
export type PluginConfig = Omit<Config, 'plugins' | 'dangerously_overrideRolldownOptions'>;

export type Plugin = rolldown.Plugin & {
  config?:
    | PluginConfig
    | ((config: PluginConfig) => PluginConfig | null | void)
    | ((config: PluginConfig) => Promise<PluginConfig | null | void>);
  configResolved?: (config: ResolvedConfig) => void | Promise<void>;
};
```

```ts
import type { Plugin } from 'rollipop';

export function demoPlugin(): Plugin {
  return {
    name: 'demo',
    config(userConfig) {
      // Case 1. Modify options
      userConfig.root = '/path/to/root';

      // Case 2. Returns options
      return {
        transformer: {
          define: {
            __DEMO__: 'true',
          },
        },
      };
    },
    configResolved(config) {
      console.log('Resolved!', config);
    },
  };
}

```