### PR TITLE
feat: improve `configureServer` plugin hook

### DIFF
--- a/.changeset/chilly-carrots-attack.md
+++ b/.changeset/chilly-carrots-attack.md
@@ -1,0 +1,6 @@
+---
+"rollipop": patch
+"@rollipop/core": patch
+---
+
+imptove `configureServer` hook

--- a/.changeset/happy-teeth-search.md
+++ b/.changeset/happy-teeth-search.md
@@ -1,7 +1,6 @@
 ---
 "@rollipop/common": minor
 "@rollipop/core": minor
-"@rollipop/dev-server": minor
 "rollipop": minor
 ---
 

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -4,7 +4,6 @@
   "initialVersions": {
     "@rollipop/common": "0.0.0",
     "@rollipop/core": "0.0.0",
-    "@rollipop/dev-server": "0.0.0",
     "rollipop": "0.0.0"
   },
   "changesets": [

--- a/packages/core/src/core/plugins/types.ts
+++ b/packages/core/src/core/plugins/types.ts
@@ -2,14 +2,12 @@ import type * as rolldown from 'rolldown';
 
 import type { Config, ResolvedConfig } from '../../config';
 import type { DevServer } from '../../server';
+import type { AsyncResult } from '../types';
 
 export type PluginConfig = Omit<Config, 'plugins' | 'dangerously_overrideRolldownOptions'>;
 
 export type Plugin = rolldown.Plugin & {
-  config?:
-    | PluginConfig
-    | ((config: PluginConfig) => PluginConfig | null | void)
-    | ((config: PluginConfig) => Promise<PluginConfig | null | void>);
-  configResolved?: (config: ResolvedConfig) => void | Promise<void>;
-  configureServer?: (server: DevServer) => void | Promise<void>;
+  config?: PluginConfig | ((config: PluginConfig) => AsyncResult<PluginConfig | null | void>);
+  configResolved?: (config: ResolvedConfig) => AsyncResult<void>;
+  configureServer?: (server: DevServer) => AsyncResult<void | (() => AsyncResult<void>)>;
 };

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -1,5 +1,5 @@
 import type { FileStorage } from '@rollipop/common';
-import { DevOptions } from 'rolldown/experimental';
+import type { DevOptions } from 'rolldown/experimental';
 
 import type { FileSystemCache } from './cache/file-system-cache';
 
@@ -59,3 +59,5 @@ export interface BundlerContext {
 }
 
 export type BuildMode = 'build' | 'serve';
+
+export type AsyncResult<T> = T | Promise<T>;

--- a/packages/core/src/server/__tests__/create-dev-server.spec.ts
+++ b/packages/core/src/server/__tests__/create-dev-server.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, vitest } from 'vitest';
+
+import { createTestConfig } from '../../testing/config';
+import { createDevServer } from '../create-dev-server';
+
+vitest.mock('@react-native-community/cli-server-api', () => ({
+  createDevServerMiddleware: vi.fn().mockReturnValue({
+    middleware: vi.fn(),
+    websocketEndpoints: {},
+    messageSocketEndpoint: {
+      broadcast: vi.fn(),
+    },
+    eventsSocketEndpoint: {
+      reportEvent: vi.fn(),
+    },
+  }),
+}));
+
+vitest.mock('@react-native/dev-middleware', () => ({
+  createDevMiddleware: vi.fn().mockReturnValue({
+    middleware: vi.fn(),
+    websocketEndpoints: {},
+  }),
+}));
+
+describe('createDevServer', () => {
+  it('should create a dev server', async () => {
+    const config = createTestConfig('/root/project');
+    const devServer = await createDevServer(config);
+
+    expect(devServer.instance).toBeDefined();
+    expect(devServer.instance.use).toBeDefined();
+    expect(devServer.middlewares.use).toBeDefined();
+  });
+
+  it('should invoke `configureServer` hooks from plugins', async () => {
+    const config = createTestConfig('/root/project');
+    const invokedOrder: string[] = [];
+
+    const pre = vi.fn();
+    const post = vi.fn();
+
+    config.plugins = [
+      {
+        name: 'plugin-post',
+        configureServer(server) {
+          return () => {
+            post(Boolean(server.instance));
+            invokedOrder.push('post');
+          };
+        },
+      },
+      {
+        name: 'plugin-post-async',
+        configureServer(server) {
+          return async () => {
+            post(Boolean(server.instance));
+            invokedOrder.push('post-async');
+          };
+        },
+      },
+      {
+        name: 'plugin-pre',
+        configureServer(server) {
+          pre(Boolean(server.instance));
+          invokedOrder.push('pre');
+        },
+      },
+      {
+        name: 'plugin-pre-async',
+        async configureServer(server) {
+          pre(Boolean(server.instance));
+          invokedOrder.push('pre-async');
+        },
+      },
+    ];
+
+    void (await createDevServer(config));
+
+    expect(pre).toHaveBeenCalledWith(true);
+    expect(post).toHaveBeenCalledWith(true);
+    expect(invokedOrder).toEqual(['pre', 'pre-async', 'post', 'post-async']);
+  });
+});

--- a/packages/core/src/server/__tests__/create-dev-server.spec.ts
+++ b/packages/core/src/server/__tests__/create-dev-server.spec.ts
@@ -1,3 +1,4 @@
+// oxlint-disable typescript-eslint(unbound-method)
 import { describe, expect, it, vi, vitest } from 'vitest';
 
 import { createTestConfig } from '../../testing/config';

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -5,12 +5,12 @@
 
 import type { FastifyInstance } from 'fastify';
 import type * as ws from 'ws';
-
+// Extend Fastify instance type with `@fastify/middie`.
+import '@fastify/middie';
 import type { ResolvedConfig } from '../config';
 import type { WebSocketClient } from './wss/server';
 
 export interface ServerOptions {
-  projectRoot: string;
   port?: number;
   host?: string;
   https?: boolean;
@@ -22,15 +22,28 @@ export interface ServerOptions {
   onDeviceDisconnected?: (client: WebSocketClient) => void;
 }
 
+export interface Middlewares {
+  /**
+   * Register a middleware to the Fastify instance.
+   *
+   * **NOTE**: This is a wrapper of `instance.use`.
+   */
+  use: FastifyInstance['use'];
+}
+
 export interface DevServer {
+  /**
+   * Resolved Rollipop config.
+   */
+  config: ResolvedConfig;
   /**
    * The Fastify instance.
    */
   instance: FastifyInstance;
   /**
-   * Resolved Rollipop config.
+   * `express` and `connect` style middleware registration API.
    */
-  config: ResolvedConfig;
+  middlewares: Middlewares;
   /**
    * The message websocket API.
    */

--- a/packages/core/src/testing/config.ts
+++ b/packages/core/src/testing/config.ts
@@ -1,0 +1,64 @@
+import path from 'node:path';
+
+import { noop } from 'es-toolkit';
+
+import type { Config, ResolvedConfig } from '../config';
+import {
+  DEFAULT_ASSET_EXTENSIONS,
+  DEFAULT_ASSET_REGISTRY_PATH,
+  DEFAULT_RESOLVER_CONDITION_NAMES,
+  DEFAULT_RESOLVER_MAIN_FIELDS,
+  DEFAULT_SOURCE_EXTENSIONS,
+} from '../constants';
+import type { Reporter } from '../types';
+
+export function createTestConfig(basePath: string): ResolvedConfig {
+  const defaultConfig = {
+    root: basePath,
+    entry: 'index.js',
+    resolver: {
+      sourceExtensions: DEFAULT_SOURCE_EXTENSIONS,
+      assetExtensions: DEFAULT_ASSET_EXTENSIONS,
+      mainFields: DEFAULT_RESOLVER_MAIN_FIELDS,
+      conditionNames: DEFAULT_RESOLVER_CONDITION_NAMES,
+      preferNativePlatform: true,
+    },
+    transformer: {
+      svg: true,
+      flow: {
+        filter: {
+          id: /\.jsx?$/,
+          code: /@flow/,
+        },
+      },
+    },
+    serializer: {
+      prelude: [path.join(basePath, '__tests__/react-native/Libraries/Core/InitializeCore.js')],
+      polyfills: [
+        {
+          type: 'iife',
+          code: 'console.log("[TEST] Polyfill")',
+        },
+      ],
+    },
+    watcher: {
+      skipWrite: true,
+      useDebounce: true,
+      debounceDuration: 50,
+    },
+    reactNative: {
+      codegen: {
+        filter: {
+          code: /codegenNativeComponent/,
+        },
+      },
+      assetRegistryPath: DEFAULT_ASSET_REGISTRY_PATH,
+    },
+    terminal: {
+      status: process.stderr.isTTY ? 'progress' : 'compat',
+    },
+    reporter: { update: noop } as Reporter,
+  } satisfies Config;
+
+  return defaultConfig;
+}

--- a/packages/core/src/utils/node-resolve.ts
+++ b/packages/core/src/utils/node-resolve.ts
@@ -5,7 +5,7 @@ export function resolvePackagePath(basePath: string, packageName: string) {
   let packagePath: string | null = null;
 
   try {
-    packagePath = resolvePackagePathWithNodeRequire(basePath, packageName);
+    packagePath = resolvePackagePathWithNodeRequire(basePath, packageName, 'package.json');
 
     if (packagePath) {
       return packagePath;
@@ -13,7 +13,7 @@ export function resolvePackagePath(basePath: string, packageName: string) {
   } catch {}
 
   try {
-    packagePath = resolvePackagePathWithNodeRequire(basePath, packageName, '');
+    packagePath = resolvePackagePathWithNodeRequire(basePath, packageName);
 
     if (packagePath) {
       return packagePath;
@@ -26,10 +26,11 @@ export function resolvePackagePath(basePath: string, packageName: string) {
 function resolvePackagePathWithNodeRequire(
   basePath: string,
   packageName: string,
-  lookupSubpath = 'package.json',
+  subpath?: string,
 ) {
-  const lookupPath = lookupSubpath ? `/${lookupSubpath}` : '';
-  const resolvedPath = require.resolve(`${packageName}${lookupPath}`, { paths: [basePath] });
+  const resolvedPath = require.resolve(subpath ? `${packageName}/${subpath}` : packageName, {
+    paths: [basePath],
+  });
   const root = path.parse(resolvedPath).root;
   let currentPath = path.dirname(resolvedPath);
 

--- a/packages/rollipop/src/node/commands/start/index.ts
+++ b/packages/rollipop/src/node/commands/start/index.ts
@@ -52,7 +52,6 @@ export const command = new Command('start')
 
     let debuggerOpened = false;
     const server = await Rollipop.runServer(config, {
-      projectRoot: cwd,
       port: options.port,
       host: options.host,
       https: options.https,


### PR DESCRIPTION
# Description

Similar to [vite](https://vite.dev/guide/api-plugin#configureserver), changed the default invocation order of `configureServer` to before rollipop middleware setup, with returned functions called after middleware setup.

Also exposed the `middlewares` interface.

```ts
{
  name: 'server-plugin',
  configureServer(server) {
    // Before rollipop middlewares are configured
    //
    // Same as
    // server.instance.use;
    server.middlewares.use(foo);


    return () => {
      // After rollipop middlewares are configured
      server.middlewares.use(bar);
    };
  },
}
```