### PR TITLE
feat: supports custom HMR handler

### DIFF
--- a/.changeset/flat-candles-scream.md
+++ b/.changeset/flat-candles-scream.md
@@ -1,5 +1,4 @@
 ---
-"@rollipop/dev-server": patch
 "@rollipop/core": patch
 ---
 

--- a/.changeset/modern-flowers-invite.md
+++ b/.changeset/modern-flowers-invite.md
@@ -1,0 +1,6 @@
+---
+"rollipop": patch
+"@rollipop/core": patch
+---
+
+supports custom HMR handler

--- a/example/index.js
+++ b/example/index.js
@@ -1,6 +1,11 @@
 import { AppRegistry } from 'react-native';
+import { setCustomHMRHandler } from 'rollipop/runtime';
 
 import { App } from './App';
 import { name as appName } from './app.json';
+
+setCustomHMRHandler((message) => {
+  console.log('Received custom HMR message:', message);
+});
 
 AppRegistry.registerComponent(appName, () => App);

--- a/example/plugins.ts
+++ b/example/plugins.ts
@@ -69,3 +69,21 @@ export function config(): Plugin {
     },
   };
 }
+
+export function hot(): Plugin {
+  let count = 0;
+  return {
+    name: 'hot',
+    configureServer(server) {
+      setInterval(() => {
+        if (server.hot.clients.size === 0) {
+          return;
+        }
+
+        server.hot.sendAll(
+          JSON.stringify({ type: 'my-custom', message: `Hello, world! ${count++}` }),
+        );
+      }, 5_000);
+    },
+  };
+}

--- a/example/rollipop.config.ts
+++ b/example/rollipop.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from 'rollipop';
 
-import { config, worklet } from './plugins';
+import { config, hot, worklet } from './plugins';
 
 export default defineConfig({
   entry: 'index.js',
-  plugins: [worklet(), config()],
+  plugins: [worklet(), config(), hot()],
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./runtime": {
+      "import": {
+        "types": "./dist/runtime.d.ts",
+        "default": "./dist/runtime.js"
+      },
+      "require": {
+        "types": "./dist/runtime.d.cts",
+        "default": "./dist/runtime.cjs"
+      }
+    },
     "./hmr-runtime": "./dist/hmr-runtime.js",
     "./hmr-client": "./dist/hmr-client.cjs",
     "./package.json": "./package.json"

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1,0 +1,21 @@
+import type { HMRCustomHandler } from './types/hmr';
+
+declare var __DEV__: boolean;
+
+declare global {
+  var __ROLLIPOP_CUSTOM_HMR_HANDLER__: HMRCustomHandler | undefined;
+}
+
+/**
+ * Set a custom HMR handler.
+ *
+ * @param handler - The custom HMR handler to set.
+ */
+export function setCustomHMRHandler(handler: HMRCustomHandler) {
+  if (__DEV__) {
+    if (globalThis.__ROLLIPOP_CUSTOM_HMR_HANDLER__ != null) {
+      console.warn('Custom HMR handler already set. replacing existing handler.');
+    }
+    globalThis.__ROLLIPOP_CUSTOM_HMR_HANDLER__ = handler;
+  }
+}

--- a/packages/core/src/runtime/hmr-client.ts
+++ b/packages/core/src/runtime/hmr-client.ts
@@ -1,4 +1,10 @@
-import type { HMRClientLogLevel, HMRClientMessage, HMRServerMessage } from '../types/hmr';
+import type {
+  HMRClientLogLevel,
+  HMRClientMessage,
+  HMRCustomHandler,
+  HMRCustomServerMessage,
+  HMRServerMessage,
+} from '../types/hmr';
 
 const Platform = require('./Platform').default as { OS: string };
 const prettyFormat = require('pretty-format');
@@ -31,6 +37,10 @@ interface HMRClientNativeInterface {
 interface SocketInstance {
   socket: WebSocket;
   origin: string;
+}
+
+declare global {
+  var __ROLLIPOP_CUSTOM_HMR_HANDLER__: HMRCustomHandler | undefined;
 }
 
 class HMRClient implements HMRClientNativeInterface {
@@ -293,6 +303,10 @@ class HMRClient implements HMRClientNativeInterface {
       case 'hmr:error':
         this.compileErrorMessage = data.payload.message;
         this.showCompileErrorIfNeeded();
+        break;
+
+      default:
+        globalThis.__ROLLIPOP_CUSTOM_HMR_HANDLER__?.(data as HMRCustomServerMessage);
         break;
     }
   }

--- a/packages/core/src/server/__tests__/create-dev-server.spec.ts
+++ b/packages/core/src/server/__tests__/create-dev-server.spec.ts
@@ -9,9 +9,11 @@ vitest.mock('@react-native-community/cli-server-api', () => ({
     middleware: vi.fn(),
     websocketEndpoints: {},
     messageSocketEndpoint: {
+      server: {},
       broadcast: vi.fn(),
     },
     eventsSocketEndpoint: {
+      server: {},
       reportEvent: vi.fn(),
     },
   }),

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -8,7 +8,7 @@ import type * as ws from 'ws';
 // Extend Fastify instance type with `@fastify/middie`.
 import '@fastify/middie';
 import type { ResolvedConfig } from '../config';
-import type { WebSocketClient } from './wss/server';
+import type { BufferLike, WebSocketClient } from './wss/server';
 
 export interface ServerOptions {
   port?: number;
@@ -45,22 +45,29 @@ export interface DevServer {
    */
   middlewares: Middlewares;
   /**
-   * The message websocket API.
+   * The message websocket server API.
    */
-  message: {
+  message: ws.Server & {
     /**
      * Broadcast a message to all connected devices.
      */
     broadcast: (method: string, params?: Record<string, any>) => void;
   };
   /**
-   * The events websocket API.
+   * The events websocket server API.
    */
-  events: {
+  events: ws.Server & {
     /**
      * Report an event to the reporter.
      */
     reportEvent: (event: { type: string; [key: string]: unknown }) => void;
+  };
+  /**
+   * HMR websocket server API
+   */
+  hot: ws.Server & {
+    send: (client: ws.WebSocket, data: BufferLike) => void;
+    sendAll: (data: BufferLike) => void;
   };
 }
 

--- a/packages/core/src/server/wss/server.ts
+++ b/packages/core/src/server/wss/server.ts
@@ -23,7 +23,7 @@ export interface WebSocketEventMap {
 
 export abstract class WebSocketServer extends EventEmitter {
   protected clientId = 0;
-  protected wss: ws.WebSocketServer;
+  protected wss: ws.Server;
   protected logger: Logger;
 
   constructor(name: string, options?: ws.ServerOptions) {
@@ -64,13 +64,13 @@ export abstract class WebSocketServer extends EventEmitter {
     return this.wss;
   }
 
-  protected send(client: ws.WebSocket, data: BufferLike) {
+  send(client: ws.WebSocket, data: BufferLike) {
     if (client.readyState === ws.WebSocket.OPEN) {
       client.send(data);
     }
   }
 
-  protected sendAll(data: BufferLike) {
+  sendAll(data: BufferLike) {
     this.wss.clients.forEach((client) => {
       if (client.readyState === ws.WebSocket.OPEN) {
         client.send(data);

--- a/packages/core/src/types/hmr.ts
+++ b/packages/core/src/types/hmr.ts
@@ -48,6 +48,13 @@ export type HMRServerMessage =
       payload: HMRServerError;
     };
 
+export type HMRCustomServerMessage = {
+  type: string;
+  payload: unknown;
+};
+
+export type HMRCustomHandler = (message: HMRCustomServerMessage) => void;
+
 export interface HMRServerError {
   type: string;
   message: string;

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -35,6 +35,14 @@ export default defineConfig([
   },
   {
     ...runtimeConfig,
+    entry: 'src/runtime.ts',
+    format: ['esm', 'cjs'],
+    platform: 'neutral',
+    fixedExtension: false,
+    dts: true,
+  },
+  {
+    ...runtimeConfig,
     entry: 'src/runtime/hmr-runtime.ts',
   },
   {

--- a/packages/rollipop/package.json
+++ b/packages/rollipop/package.json
@@ -14,6 +14,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./runtime": {
+      "import": {
+        "types": "./dist/runtime.d.ts",
+        "default": "./dist/runtime.js"
+      },
+      "require": {
+        "types": "./dist/runtime.d.cts",
+        "default": "./dist/runtime.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/rollipop/src/runtime.ts
+++ b/packages/rollipop/src/runtime.ts
@@ -1,0 +1,1 @@
+export * from '@rollipop/core/runtime';

--- a/packages/rollipop/tsdown.config.ts
+++ b/packages/rollipop/tsdown.config.ts
@@ -1,10 +1,20 @@
 import { defineConfig } from 'tsdown';
 
-export default defineConfig({
-  entry: 'src/index.ts',
-  outDir: 'dist',
-  format: ['esm', 'cjs'],
-  platform: 'node',
-  fixedExtension: false,
-  dts: true,
-});
+export default defineConfig([
+  {
+    entry: 'src/index.ts',
+    outDir: 'dist',
+    format: ['esm', 'cjs'],
+    platform: 'node',
+    fixedExtension: false,
+    dts: true,
+  },
+  {
+    entry: 'src/runtime.ts',
+    outDir: 'dist',
+    format: ['esm', 'cjs'],
+    platform: 'neutral',
+    fixedExtension: false,
+    dts: true,
+  },
+]);


### PR DESCRIPTION
# Description

The HMR websocket server can be accessed through the `configureServer` hook, allowing custom messages to be sent to clients (React Native App).

Applications can register message handlers using `setCustomHMRHandler` from `rollipop/runtime`.

This feature is only available in `dev` mode.

```ts
// Application
import { setCustomHMRHandler } from 'rollipop/runtime';

setCustomHMRHandler((message) => {
  console.log('Received custom HMR message:', message);
});
```

```ts
// Plugin
export function hot(): Plugin {
  let count = 0;
  return {
    name: 'hot',
    configureServer(server) {
      server.hot; // HMR websocket server

      setInterval(() => {
        const isConnected = server.hot.clients.size > 0;

        if (!isConnected) {
          return;
        }

        // Send message to all connected clients
        server.hot.sendAll(
          JSON.stringify({ type: 'my-custom', message: `Hello, world! ${count++}` }),
        );
      }, 5_000);
    },
  };
}
```

<img width="721" height="112" alt="Screenshot 2025-12-24 at 23 22 24" src="https://github.com/user-attachments/assets/4d44af94-4528-4748-82d6-215068ea3778" />