### PR TITLE
feat: bind context to Rollipop-specific hooks

### DIFF
--- a/.changeset/eleven-guests-burn.md
+++ b/.changeset/eleven-guests-burn.md
@@ -1,0 +1,6 @@
+---
+"@rollipop/common": patch
+"@rollipop/core": patch
+---
+
+bind plugin context to rollipop custom hooks

--- a/example/plugins.ts
+++ b/example/plugins.ts
@@ -77,7 +77,10 @@ export function hot(): Plugin {
     configureServer(server) {
       setInterval(() => {
         if (server.hot.clients.size === 0) {
+          this.debug('No clients connected, skipping sending message');
           return;
+        } else {
+          this.debug('Sending message to clients...');
         }
 
         server.hot.sendAll(

--- a/packages/core/src/core/plugins/context.ts
+++ b/packages/core/src/core/plugins/context.ts
@@ -1,0 +1,33 @@
+import { chalk, Logger } from '@rollipop/common';
+import type { LogLevel, RollupLogWithString } from 'rolldown';
+
+export const pluginLogger = new Logger();
+
+export interface PluginContext {
+  debug: (log: RollupLogWithString) => void;
+  info: (log: RollupLogWithString) => void;
+  warn: (log: RollupLogWithString) => void;
+}
+
+export function createPluginContext(name: string | undefined): PluginContext {
+  return {
+    debug: (log: RollupLogWithString) => {
+      printPluginLog('debug', log, name);
+    },
+    info: (log: RollupLogWithString) => {
+      printPluginLog('info', log, name);
+    },
+    warn: (log: RollupLogWithString) => {
+      printPluginLog('warn', log, name);
+    },
+  };
+}
+
+export function printPluginLog(level: LogLevel, log: RollupLogWithString, pluginName = 'unknown') {
+  const pluginLabel = chalk.magenta(`plugin:${pluginName}`);
+  if (typeof log === 'string') {
+    pluginLogger[level](pluginLabel, log);
+  } else {
+    pluginLogger[level](pluginLabel, log.stack ?? log.message);
+  }
+}

--- a/packages/core/src/core/plugins/types.ts
+++ b/packages/core/src/core/plugins/types.ts
@@ -3,11 +3,17 @@ import type * as rolldown from 'rolldown';
 import type { Config, ResolvedConfig } from '../../config';
 import type { DevServer } from '../../server';
 import type { AsyncResult } from '../types';
+import type { PluginContext } from './context';
 
 export type PluginConfig = Omit<Config, 'plugins' | 'dangerously_overrideRolldownOptions'>;
 
 export type Plugin = rolldown.Plugin & {
-  config?: PluginConfig | ((config: PluginConfig) => AsyncResult<PluginConfig | null | void>);
-  configResolved?: (config: ResolvedConfig) => AsyncResult<void>;
-  configureServer?: (server: DevServer) => AsyncResult<void | (() => AsyncResult<void>)>;
+  config?:
+    | PluginConfig
+    | ((this: PluginContext, config: PluginConfig) => AsyncResult<PluginConfig | null | void>);
+  configResolved?: (this: PluginContext, config: ResolvedConfig) => AsyncResult<void>;
+  configureServer?: (
+    this: PluginContext,
+    server: DevServer,
+  ) => AsyncResult<void | (() => AsyncResult<void>)>;
 };

--- a/packages/core/src/server/create-dev-server.ts
+++ b/packages/core/src/server/create-dev-server.ts
@@ -5,6 +5,7 @@ import { createDevMiddleware } from '@react-native/dev-middleware';
 import Fastify from 'fastify';
 
 import type { ResolvedConfig } from '../config';
+import { createPluginContext } from '../core/plugins/context';
 import type { Plugin } from '../core/plugins/types';
 import type { AsyncResult, BuildOptions } from '../core/types';
 import { assertDevServerStatus } from '../utils/dev-server';
@@ -143,7 +144,8 @@ async function invokeConfigureServer(server: DevServer, plugins: Plugin[]) {
   const postConfigureServerHandlers: (() => AsyncResult<void>)[] = [];
 
   for (const plugin of plugins) {
-    const result = await plugin.configureServer?.(server);
+    const context = createPluginContext(plugin.name);
+    const result = await plugin.configureServer?.call(context, server);
 
     if (typeof result === 'function') {
       postConfigureServerHandlers.push(result);


### PR DESCRIPTION
# Description

Rollipop-specific hooks like `config`, `configResolved`, `configureServer` previously lacked a bound context, unlike Rolldown plugin hooks.

Now binds the same context as Rolldown plugin context (`debug`, `info`, `warn`) to enable logger usage in Rollipop-specific hooks.

<img width="444" height="110" alt="Screenshot 2025-12-25 at 00 22 13" src="https://github.com/user-attachments/assets/048c9c00-4d03-431d-b88d-fc0042dd33ce" />
