### PR TITLE
feat(cli): add `terminal.extraCommands` for supports custom commands

### DIFF
--- a/example/rollipop.config.ts
+++ b/example/rollipop.config.ts
@@ -1,12 +1,31 @@
-import { defineConfig, Plugin } from 'rollipop';
+import { defineConfig, type PluginOption } from 'rollipop';
 
 import { config, hot, worklet } from './plugins';
 
-function myPlugin(): Plugin[] {
+function myPlugin(): PluginOption {
   return [hot(), worklet(), config()];
 }
 
 export default defineConfig({
   entry: 'index.js',
   plugins: [myPlugin()],
+  terminal: {
+    extraCommands: [
+      {
+        key: 'a',
+        description: 'My custom command 1',
+        handler: () => {
+          console.log('My custom command 1');
+        },
+      },
+      {
+        key: 'a',
+        shift: true,
+        description: 'My custom command 2',
+        handler: () => {
+          console.log('My custom command 2');
+        },
+      },
+    ],
+  },
 });

--- a/packages/rollipop/src/config/types.ts
+++ b/packages/rollipop/src/config/types.ts
@@ -5,6 +5,7 @@ import type * as rolldown from 'rolldown';
 import type { DevWatchOptions, TransformOptions } from 'rolldown/experimental';
 
 import type { Plugin } from '../core/plugins/types';
+import { InteractiveCommand } from '../node/cli-utils';
 import type { MaybePromise, NullValue, Reporter } from '../types';
 
 export interface Config {
@@ -161,7 +162,7 @@ export type WatcherConfig = DevWatchOptions;
 export interface DevModeConfig {
   /**
    * Hot Module Replacement configurations.
-   * 
+   *
    * Defaults to `true`
    */
   hmr?: boolean | HmrConfig;
@@ -176,7 +177,7 @@ export interface HmrConfig {
   runtimeImplement?: string;
   /**
    * Source code of the HMR client implementation.
-   * 
+   *
    * Defaults to: using `rollipop/hmr-client` as a default implementation.
    */
   clientImplement?: string;
@@ -209,6 +210,10 @@ export interface TerminalConfig {
    * Defaults to: `process.stderr.isTTY ? 'progress' : 'compat'`
    */
   status?: 'none' | 'compat' | 'progress';
+  /**
+   * Extra commands to display in the interactive mode.
+   */
+  extraCommands?: InteractiveCommand[];
 }
 
 export interface RolldownConfig {

--- a/packages/rollipop/src/node/commands/start/index.ts
+++ b/packages/rollipop/src/node/commands/start/index.ts
@@ -49,7 +49,7 @@ export const command = new Command('start')
       config.reporter = { update: noop };
     }
 
-    const server = await Rollipop.runServer(config, {
+    const devServer = await Rollipop.runServer(config, {
       port: options.port,
       host: options.host,
       https: options.https,
@@ -58,6 +58,6 @@ export const command = new Command('start')
     });
 
     if (options.interactive) {
-      setupInteractiveMode(server);
+      setupInteractiveMode({ devServer, extraCommands: config.terminal?.extraCommands });
     }
   });

--- a/packages/rollipop/src/node/commands/start/setup-interactive-mode.ts
+++ b/packages/rollipop/src/node/commands/start/setup-interactive-mode.ts
@@ -4,6 +4,7 @@ import { ReadStream } from 'node:tty';
 import chalk from 'chalk';
 import { throttle } from 'es-toolkit';
 
+import type { Logger } from '../../../common/logger';
 import type { DevServer } from '../../../server';
 import { logger } from '../../logger';
 import { DebuggerOpener } from './debugger';
@@ -11,34 +12,26 @@ import { DebuggerOpener } from './debugger';
 const CTRL_C = '\x03';
 const CTRL_D = '\x04';
 const BROADCAST_THROTTLE_DELAY = 500;
-const SUPPORTED_COMMANDS = {
-  r: {
-    description: 'Reload app',
-    handler: throttle((broadcast) => {
-      logger.info('Reloading app...');
-      broadcast('reload');
-    }, BROADCAST_THROTTLE_DELAY),
-  },
-  j: {
-    description: 'Open DevTools',
-  },
-  d: {
-    description: 'Show developer menu',
-    handler: throttle((broadcast) => {
-      logger.info('Showing developer menu...');
-      broadcast('devMenu');
-    }, BROADCAST_THROTTLE_DELAY),
-  },
-} satisfies Record<string, InteractiveCommand>;
-
-type Broadcast = (message: string, params?: Record<string, any>) => void;
 
 export interface InteractiveCommand {
-  description: string;
-  handler?: (broadcast: Broadcast) => void;
+  key: string;
+  shift?: boolean;
+  description: string | (() => string);
+  handler: (this: InteractiveCommandContext) => void;
 }
 
-export function setupInteractiveMode(devServer: DevServer) {
+export interface InteractiveCommandContext {
+  logger: Logger;
+}
+
+export interface InteractiveModeOptions {
+  devServer: DevServer;
+  extraCommands?: InteractiveCommand[];
+}
+
+export function setupInteractiveMode(options: InteractiveModeOptions) {
+  const { devServer, extraCommands = [] } = options;
+
   if (!devServer.instance.server.listening) {
     throw new Error(
       'Dev server is not listening. Please call `devServer.instance.listen()` first.',
@@ -50,13 +43,17 @@ export function setupInteractiveMode(devServer: DevServer) {
     return;
   }
 
-  readline.emitKeypressEvents(process.stdin);
-  process.stdin.setRawMode(true);
-
   const debuggerOpener = new DebuggerOpener(
     devServer.config.root,
     devServer.instance.listeningOrigin,
   );
+
+  const defaultCommands = getDefaultCommands(devServer, debuggerOpener);
+  const allCommands = [...defaultCommands, ...extraCommands];
+  assertHasNoDuplicateCommands(defaultCommands, extraCommands);
+
+  readline.emitKeypressEvents(process.stdin);
+  process.stdin.setRawMode(true);
 
   devServer.on('device.connected', () => {
     void debuggerOpener.autoOpen().catch(() => {
@@ -65,7 +62,7 @@ export function setupInteractiveMode(devServer: DevServer) {
   });
 
   process.stdin.on('keypress', (_, key: readline.Key) => {
-    const { ctrl, shift } = key;
+    const { ctrl = false, shift = false } = key;
     const sequence = key.sequence?.toLowerCase();
 
     if (sequence == null || debuggerOpener.isPrompting()) {
@@ -79,40 +76,101 @@ export function setupInteractiveMode(devServer: DevServer) {
       process.exit(0);
     }
 
-    if (shift && sequence.toLowerCase() === 'd') {
-      const autoOpenEnabled = debuggerOpener.isAutoOpenEnabled();
-      const newAutoOpenEnabled = !autoOpenEnabled;
-      debuggerOpener.setAutoOpenEnabled(newAutoOpenEnabled);
-      logger.info(
-        `Auto opening developer tools: ${chalk.bold(newAutoOpenEnabled ? 'enabled' : 'disabled')}`,
-      );
-      return;
-    }
+    const targetCommand = allCommands.find(
+      (command) => command.key === sequence && (command.shift ?? false) === shift,
+    );
 
-    switch (sequence) {
-      case 'r':
-      case 'd':
-        SUPPORTED_COMMANDS[sequence].handler(devServer.message.broadcast);
-        break;
-
-      case 'j':
-        void debuggerOpener.open().catch(() => {
-          logger.error('Failed to open debugger');
-        });
-        break;
+    if (targetCommand) {
+      targetCommand.handler.call({ logger });
     }
   });
 
   console.log();
-  Object.entries(SUPPORTED_COMMANDS).forEach(([key, command]) => {
-    const keyLabel = `» Press ${chalk.bold(key)} │`;
-    console.log(`${keyLabel} ${command.description}`);
-  });
+  allCommands.forEach((command, index) => {
+    if (defaultCommands.length === index) {
+      console.log(); // Extra commands separator
+    }
 
-  // Extra
-  const keyLabel = `» ${chalk.bold('shift+d')} │`;
-  const autoOpenStatus = `(${debuggerOpener.isAutoOpenEnabled() ? 'enabled' : 'disabled'})`;
-  console.log(
-    `${keyLabel} Toggle auto opening developer tools on startup ${`${chalk.gray.bold(autoOpenStatus)}`}`,
-  );
+    const leadingLabel = command.shift ? '»' : '» Press';
+    const shortcut = chalk.bold(shortcutLabel(command.key, command.shift));
+    console.log(
+      `${leadingLabel} ${shortcut} │ ${typeof command.description === 'function' ? command.description() : command.description}`,
+    );
+  });
+}
+
+function getDefaultCommands(
+  devServer: DevServer,
+  debuggerOpener: DebuggerOpener,
+): InteractiveCommand[] {
+  return [
+    {
+      key: 'r',
+      description: 'Reload app',
+      handler: throttle(() => {
+        logger.info('Reloading app...');
+        devServer.message.broadcast('reload');
+      }, BROADCAST_THROTTLE_DELAY),
+    },
+    {
+      key: 'j',
+      description: 'Open DevTools',
+      handler: () => {
+        debuggerOpener.open().catch(() => {
+          logger.error('Failed to open debugger');
+        });
+      },
+    },
+    {
+      key: 'd',
+      description: 'Show developer menu',
+      handler: throttle(() => {
+        logger.info('Showing developer menu...');
+        devServer.message.broadcast('devMenu');
+      }, BROADCAST_THROTTLE_DELAY),
+    },
+    {
+      key: 'd',
+      shift: true,
+      description: () => {
+        const autoOpenEnabled = debuggerOpener.isAutoOpenEnabled();
+        return `Toggle auto opening developer tools on startup (${chalk.bold(autoOpenEnabled ? 'enabled' : 'disabled')})`;
+      },
+      handler: () => {
+        const autoOpenEnabled = debuggerOpener.isAutoOpenEnabled();
+        const newAutoOpenEnabled = !autoOpenEnabled;
+        debuggerOpener.setAutoOpenEnabled(newAutoOpenEnabled);
+        logger.info(
+          `Auto opening developer tools: ${chalk.bold(newAutoOpenEnabled ? 'enabled' : 'disabled')}`,
+        );
+      },
+    },
+  ];
+}
+
+function shortcutLabel(key: string, shift?: boolean) {
+  if (shift) {
+    return `shift+${key}`;
+  }
+  return key;
+}
+
+function assertHasNoDuplicateCommands(
+  defaultCommands: InteractiveCommand[],
+  commands: InteractiveCommand[],
+) {
+  const defaultCommandKeys = defaultCommands.map(({ key, shift }) => shortcutLabel(key, shift));
+  const commandKeys = commands.map(({ key, shift }) => shortcutLabel(key, shift));
+  const duplicateKeys = commandKeys.filter((key) => defaultCommandKeys.includes(key));
+
+  const invalidCommandKeys = commands
+    .filter(({ key }) => key.length > 1)
+    .map(({ key, shift }) => shortcutLabel(key, shift));
+  if (invalidCommandKeys.length > 0) {
+    throw new Error(`Invalid commands: ${invalidCommandKeys.join(', ')}`);
+  }
+
+  if (duplicateKeys.length > 0) {
+    throw new Error(`Duplicate commands: ${duplicateKeys.join(', ')}`);
+  }
 }


### PR DESCRIPTION
# Description

Add an option to support custom extra command extensions.

Users can add their own shortcut commands as long as they don't conflict with the built-in commands.

**Usage**

```ts
// Case 1. User config
import { defineConfig } from 'rollipop';

export default defineConfig({
  terminal: {
    extraCommands: [
      {
        key: 'a',
        description: 'My custom command 1',
        handler: () => {
          console.log('My custom command 1');
        },
      },
      {
        key: 'a',
        shift: true,
        description: 'My custom command 2',
        handler: () => {
          console.log('My custom command 2');
        },
      },
    ],
  },
});

// Case 2. Advanced usage
import * as Rollipop from 'rollipop';

const devServer = Rollipop.runServer(...);

Rollipop.setupInteractiveMode({
  devServer,
  extraCommands: [
    {
      key: 'a',
      description: 'My custom command 1',
      handler: () => {
        console.log('My custom command 1');
      },
    },
    {
      key: 'a',
      shift: true,
      description: 'My custom command 2',
      handler: () => {
        console.log('My custom command 2');
      },
    },
  ],
});
```

<img width="545" height="189" alt="Screenshot 2026-01-09 at 02 17 13" src="https://github.com/user-attachments/assets/b3f22ae9-00a0-448c-b8fd-5ccd658c9893" />
