### PR TITLE
feat: add dotenv-based environment variable loading

### DIFF
--- a/.changeset/frank-dragons-enter.md
+++ b/.changeset/frank-dragons-enter.md
@@ -1,0 +1,5 @@
+---
+"rollipop": patch
+---
+
+add dotenv-based environment variable loading

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dist
 .DS_Store
 
 package.tgz
+
+# local env files
+*.local

--- a/example/.env
+++ b/example/.env
@@ -1,0 +1,1 @@
+ROLLIPOP_DESCRIPTION="Modern build toolkit for React Native"

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -30,7 +30,7 @@ function HomeScreen() {
       </Animated.View>
       <View style={styles.descriptionContainer}>
         <Text style={styles.title}>Rollipop</Text>
-        <Text style={styles.description}>Modern build toolkit for React Native</Text>
+        <Text style={styles.description}>{import.meta.env.ROLLIPOP_DESCRIPTION}</Text>
       </View>
     </View>
   );

--- a/example/rollipop.d.ts
+++ b/example/rollipop.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="rollipop/client" />
+
+interface ImportMetaEnv {
+  readonly ROLLIPOP_DESCRIPTION: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/rollipop/client.d.ts
+++ b/packages/rollipop/client.d.ts
@@ -1,3 +1,4 @@
 interface ImportMeta {
   hot?: import('./dist').HMRContext;
+  env: ImportMetaEnv;
 }

--- a/packages/rollipop/package.json
+++ b/packages/rollipop/package.json
@@ -88,6 +88,8 @@
     "commander": "^14.0.2",
     "dayjs": "^1.11.19",
     "dedent": "^1.7.1",
+    "dotenv": "^17.2.3",
+    "dotenv-expand": "^12.0.3",
     "es-toolkit": "catalog:",
     "fastify": "^5.6.2",
     "fastify-plugin": "^5.1.0",

--- a/packages/rollipop/src/config/defaults.ts
+++ b/packages/rollipop/src/config/defaults.ts
@@ -6,6 +6,7 @@ import { generateSourceFromAst, stripFlowSyntax } from '../common/transformer';
 import {
   DEFAULT_ASSET_EXTENSIONS,
   DEFAULT_ASSET_REGISTRY_PATH,
+  DEFAULT_ENV_PREFIX,
   DEFAULT_RESOLVER_CONDITION_NAMES,
   DEFAULT_RESOLVER_MAIN_FIELDS,
   DEFAULT_SOURCE_EXTENSIONS,
@@ -16,11 +17,12 @@ import { resolvePackagePath } from '../utils/node-resolve';
 import type { PluginFlattenConfig } from './merge-config';
 import type { Config, Polyfill, TerminalConfig } from './types';
 
-export function getDefaultConfig(basePath: string) {
+export function getDefaultConfig(basePath: string, mode?: Config['mode']) {
   const reactNativePath = resolvePackagePath(basePath, 'react-native');
 
   const defaultConfig = {
     root: basePath,
+    mode,
     entry: 'index.js',
     resolver: {
       sourceExtensions: DEFAULT_SOURCE_EXTENSIONS,
@@ -80,6 +82,8 @@ export function getDefaultConfig(basePath: string) {
       })(),
     },
     reporter: new TerminalReporter() as Reporter,
+    envDir: basePath,
+    envPrefix: DEFAULT_ENV_PREFIX,
   } satisfies Config;
 
   return defaultConfig;

--- a/packages/rollipop/src/config/load-config.ts
+++ b/packages/rollipop/src/config/load-config.ts
@@ -15,13 +15,14 @@ const CONFIG_FILE_NAME = 'rollipop';
 export interface LoadConfigOptions {
   cwd?: string;
   configFile?: string;
+  mode?: Config['mode'];
   context?: Omit<DefineConfigContext, 'defaultConfig'>;
 }
 
 export async function loadConfig(options: LoadConfigOptions = {}) {
-  const { cwd = process.cwd(), configFile, context = {} } = options;
+  const { cwd = process.cwd(), configFile, mode, context = {} } = options;
 
-  const defaultConfig = getDefaultConfig(cwd);
+  const defaultConfig = getDefaultConfig(cwd, mode);
   const commonOptions: c12.LoadConfigOptions = {
     context: { ...context, defaultConfig },
     rcFile: false,

--- a/packages/rollipop/src/config/types.ts
+++ b/packages/rollipop/src/config/types.ts
@@ -14,6 +14,12 @@ export interface Config {
    */
   root?: string;
   /**
+   * Specifying this in config will override the default mode for both serve and build.
+   *
+   * Defaults to: `'development'` for serve, 'production' for build.
+   */
+  mode?: 'development' | 'production';
+  /**
    * Defaults to: `index.js`
    */
   entry?: string;
@@ -53,6 +59,18 @@ export interface Config {
    * Plugins.
    */
   plugins?: PluginOption;
+  /**
+   * Directory to load environment variables from.
+   *
+   * Defaults to: `root`
+   */
+  envDir?: string;
+  /**
+   * Environment variable prefix.
+   *
+   * Defaults to: `'ROLLIPOP_'`
+   */
+  envPrefix?: string;
   /**
    * Rollipop provides default options for Rolldown, but you can override them by this option.
    *

--- a/packages/rollipop/src/constants.ts
+++ b/packages/rollipop/src/constants.ts
@@ -72,3 +72,5 @@ export const DEFAULT_ASSET_EXTENSIONS = [
 
 export const DEFAULT_ASSET_REGISTRY_PATH = 'react-native/Libraries/Image/AssetRegistry.js';
 export const DEFAULT_HMR_CLIENT_PATH = 'react-native/Libraries/Utilities/HMRClient.js';
+
+export const DEFAULT_ENV_PREFIX = 'ROLLIPOP_';

--- a/packages/rollipop/src/core/__tests__/env.spec.ts
+++ b/packages/rollipop/src/core/__tests__/env.spec.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, it, expect, vitest, beforeEach } from 'vitest';
+
+import { DEFAULT_ENV_PREFIX } from '../../constants';
+import { loadEnv } from '../env';
+
+describe('loadEnv', () => {
+  function mockEnvFiles(files: Record<string, string>) {
+    vitest.spyOn(fs, 'existsSync').mockImplementation((pathLike) => {
+      return Boolean(files[path.basename(pathLike.toString())]);
+    });
+
+    vitest.spyOn(fs, 'readFileSync').mockImplementation((pathLike) => {
+      return files[path.basename(pathLike.toString())];
+    });
+  }
+
+  beforeEach(() => {
+    vitest.resetAllMocks();
+  });
+
+  it('should load environment variables', () => {
+    mockEnvFiles({
+      '.env': ['ROLLIPOP_FOO=1', 'ROLLIPOP_BAR=2', 'ROLLIPOP_BAZ=3'].join('\n'),
+    });
+
+    const env = loadEnv({ envDir: '.', envPrefix: DEFAULT_ENV_PREFIX });
+    expect(env).toEqual({ ROLLIPOP_FOO: '1', ROLLIPOP_BAR: '2', ROLLIPOP_BAZ: '3' });
+  });
+
+  it('should load environment variables from .env.local', () => {
+    mockEnvFiles({
+      '.env.local': ['ROLLIPOP_FOO=1', 'ROLLIPOP_BAR=2', 'ROLLIPOP_BAZ=3'].join('\n'),
+    });
+
+    const env = loadEnv({ envDir: '.', envPrefix: DEFAULT_ENV_PREFIX });
+    expect(env).toEqual({ ROLLIPOP_FOO: '1', ROLLIPOP_BAR: '2', ROLLIPOP_BAZ: '3' });
+  });
+
+  it('should load environment variables from .env.[mode]', () => {
+    mockEnvFiles({
+      '.env.development': ['ROLLIPOP_FOO=1', 'ROLLIPOP_BAR=2', 'ROLLIPOP_BAZ=3'].join('\n'),
+    });
+
+    const env = loadEnv({ envDir: '.', envPrefix: DEFAULT_ENV_PREFIX, mode: 'development' });
+    expect(env).toEqual({ ROLLIPOP_FOO: '1', ROLLIPOP_BAR: '2', ROLLIPOP_BAZ: '3' });
+  });
+
+  it('should load environment variables from `.env.[mode].local`', () => {
+    mockEnvFiles({
+      '.env.development.local': ['ROLLIPOP_FOO=1', 'ROLLIPOP_BAR=2', 'ROLLIPOP_BAZ=3'].join('\n'),
+    });
+
+    const env = loadEnv({ envDir: '.', envPrefix: DEFAULT_ENV_PREFIX, mode: 'development' });
+    expect(env).toEqual({ ROLLIPOP_FOO: '1', ROLLIPOP_BAR: '2', ROLLIPOP_BAZ: '3' });
+  });
+
+  it('should override environment variables from `.env.local` with `.env.[mode].local`', () => {
+    mockEnvFiles({
+      '.env.local': ['ROLLIPOP_FOO=1', 'ROLLIPOP_BAR=2', 'ROLLIPOP_BAZ=3'].join('\n'),
+      '.env.development.local': ['ROLLIPOP_FOO=4', 'ROLLIPOP_BAR=5'].join('\n'),
+    });
+
+    const env = loadEnv({ envDir: '.', envPrefix: DEFAULT_ENV_PREFIX, mode: 'development' });
+    expect(env).toEqual({ ROLLIPOP_FOO: '4', ROLLIPOP_BAR: '5', ROLLIPOP_BAZ: '3' });
+  });
+
+  it('should override environment variables order: `.env` -> `.env.local` -> `.env.[mode].local` -> `.env.[mode]`', () => {
+    mockEnvFiles({
+      '.env': ['ROLLIPOP_FOO=0'].join('\n'),
+      '.env.local': ['ROLLIPOP_FOO=1', 'ROLLIPOP_BAR=2'].join('\n'),
+      '.env.development': ['ROLLIPOP_FOO=7'].join('\n'),
+      '.env.development.local': ['ROLLIPOP_BAZ=6'].join('\n'),
+    });
+
+    const env = loadEnv({ envDir: '.', envPrefix: DEFAULT_ENV_PREFIX, mode: 'development' });
+    expect(env).toEqual({ ROLLIPOP_FOO: '7', ROLLIPOP_BAR: '2', ROLLIPOP_BAZ: '6' });
+  });
+});

--- a/packages/rollipop/src/core/bundler.ts
+++ b/packages/rollipop/src/core/bundler.ts
@@ -12,7 +12,7 @@ import { createId } from '../utils/id';
 import { FileSystemCache } from './cache/file-system-cache';
 import { FileStorage } from './fs/storage';
 import { getOverrideOptionsForDevServer, resolveRolldownOptions } from './rolldown';
-import type { BuildMode, BuildOptions, BundlerContext, DevEngine, DevEngineOptions } from './types';
+import type { BuildType, BuildOptions, BundlerContext, DevEngine, DevEngineOptions } from './types';
 import { BundlerState } from './types';
 
 export class Bundler {
@@ -21,9 +21,9 @@ export class Bundler {
     buildOptions: Omit<BuildOptions, 'dev' | 'outfile'>,
     devEngineOptions: DevEngineOptions,
   ) {
-    const mode = 'serve';
-    const resolvedBuildOptions = resolveBuildOptions(config.root, buildOptions);
-    const context = Bundler.createContext(mode, config, resolvedBuildOptions);
+    const buildType = 'serve';
+    const resolvedBuildOptions = resolveBuildOptions(config, buildOptions);
+    const context = Bundler.createContext(buildType, config, resolvedBuildOptions);
     const { input = {}, output = {} } = await resolveRolldownOptions(
       context,
       config,
@@ -53,7 +53,7 @@ export class Bundler {
   }
 
   private static createContext(
-    mode: BuildMode,
+    buildType: BuildType,
     config: ResolvedConfig,
     buildOptions: ResolvedBuildOptions,
   ) {
@@ -61,7 +61,7 @@ export class Bundler {
     const cache = new FileSystemCache(config.root, id);
     const storage = FileStorage.getInstance(config.root);
     const state: BundlerState = { hmrUpdates: new Set() };
-    const context: BundlerContext = { id, cache, storage, mode, state };
+    const context: BundlerContext = { id, cache, storage, buildType, state };
 
     return context;
   }
@@ -71,9 +71,9 @@ export class Bundler {
   }
 
   async build(buildOptions: BuildOptions) {
-    const mode = 'build';
-    const resolvedBuildOptions = resolveBuildOptions(this.config.root, buildOptions);
-    const context = Bundler.createContext(mode, this.config, resolvedBuildOptions);
+    const buildType = 'build';
+    const resolvedBuildOptions = resolveBuildOptions(this.config, buildOptions);
+    const context = Bundler.createContext(buildType, this.config, resolvedBuildOptions);
     const sourcemap = resolvedBuildOptions.sourcemap ? true : false;
     const { input, output } = await resolveRolldownOptions(
       context,

--- a/packages/rollipop/src/core/env.ts
+++ b/packages/rollipop/src/core/env.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import dotenv from 'dotenv';
+import dotenvExpand from 'dotenv-expand';
+import { invariant, isNotNil } from 'es-toolkit';
+
+import type { Config } from '../config';
+import { logger } from '../logger';
+
+export interface LoadEnvOptions {
+  envDir: string;
+  envPrefix: string;
+  mode?: Config['mode'];
+}
+
+export function loadEnv(options: LoadEnvOptions) {
+  const { envDir, envPrefix, mode } = options;
+  invariant(envPrefix.length > 0, '`envPrefix` is required');
+
+  const env: Record<string, string> = {};
+  const envFilesToLoad = [
+    `.env`,
+    `.env.local`,
+    mode ? `.env.${mode}` : null,
+    mode ? `.env.${mode}.local` : null,
+  ].filter(isNotNil);
+
+  for (const envFile of envFilesToLoad) {
+    const envPath = path.resolve(envDir, envFile);
+
+    if (!fs.existsSync(envPath)) {
+      continue;
+    }
+
+    logger.trace(`Loading environment variables from ${envPath}`);
+    const parsed = dotenv.parse(fs.readFileSync(envPath, 'utf-8'));
+    const expanded = dotenvExpand.expand({
+      parsed,
+      processEnv: {},
+    });
+
+    if (expanded.parsed) {
+      Object.entries(expanded.parsed).forEach(([key, value]) => {
+        if (key.startsWith(envPrefix)) {
+          env[key] = key in process.env ? (process.env[key] as string) : value;
+        }
+      });
+    }
+  }
+
+  logger.trace('Loaded environment variables:', env);
+
+  return env;
+}

--- a/packages/rollipop/src/core/plugins/react-native-plugin.ts
+++ b/packages/rollipop/src/core/plugins/react-native-plugin.ts
@@ -11,14 +11,14 @@ import {
   generateAssetRegistryCode,
   resolveScaledAssets,
 } from '../assets';
-import type { BuildMode } from '../types';
+import type { BuildType } from '../types';
 import { cacheable } from './utils';
 import { TransformFlag, getFlag, setFlag } from './utils/transform-utils';
 
 export interface ReactNativePluginOptions {
   platform: string;
   dev: boolean;
-  mode: BuildMode;
+  buildType: BuildType;
   flowFilter: rolldown.HookFilter | TopLevelFilterExpression[];
   codegenFilter: rolldown.HookFilter | TopLevelFilterExpression[];
   assetsDir?: string;
@@ -30,7 +30,7 @@ function reactNativePlugin(
   config: ResolvedConfig,
   options: ReactNativePluginOptions,
 ): rolldown.Plugin[] {
-  const { mode, flowFilter, codegenFilter, assetsDir, assetExtensions, assetRegistryPath } =
+  const { buildType, flowFilter, codegenFilter, assetsDir, assetExtensions, assetRegistryPath } =
     options;
   const assetExtensionRegex = new RegExp(`\\.(?:${assetExtensions.join('|')})$`);
 
@@ -104,7 +104,7 @@ function reactNativePlugin(
       assets.length = 0;
     },
     async buildEnd(error) {
-      if (error || mode === 'serve') {
+      if (error || buildType === 'serve') {
         return;
       }
 
@@ -150,7 +150,7 @@ function reactNativePlugin(
     },
   };
 
-  const devServerPlugins = mode === 'serve' ? [replaceHMRClientPlugin] : null;
+  const devServerPlugins = buildType === 'serve' ? [replaceHMRClientPlugin] : null;
 
   return [
     cacheable(codegenPlugin),

--- a/packages/rollipop/src/core/types.ts
+++ b/packages/rollipop/src/core/types.ts
@@ -59,7 +59,7 @@ export interface BundlerContext {
   id: string;
   cache: FileSystemCache;
   storage: FileStorage;
-  mode: BuildMode;
+  buildType: BuildType;
   state: BundlerState;
 }
 
@@ -67,6 +67,6 @@ export interface BundlerState {
   hmrUpdates: Set<string>;
 }
 
-export type BuildMode = 'build' | 'serve';
+export type BuildType = 'build' | 'serve';
 
 export type AsyncResult<T> = T | Promise<T>;

--- a/packages/rollipop/src/index.ts
+++ b/packages/rollipop/src/index.ts
@@ -18,6 +18,9 @@ export type { Plugin, PluginConfig } from './core/plugins/types';
 // Assets
 export * as AssetUtils from './core/assets';
 
+// Env
+export * from './core/env';
+
 // Config
 export * from './config';
 

--- a/packages/rollipop/src/internal/react-native.ts
+++ b/packages/rollipop/src/internal/react-native.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { isNotNil } from 'es-toolkit';
 
 import { GLOBAL_IDENTIFIER } from '../constants';
+import type { BuildType } from '../core/types';
 
 export function getInitializeCorePath(basePath: string) {
   return require.resolve('react-native/Libraries/Core/InitializeCore', { paths: [basePath] });
@@ -13,13 +14,14 @@ export function getPolyfillScriptPaths(reactNativePath: string) {
   return (require(scriptPath) as () => string[])();
 }
 
-export function getGlobalVariables(dev: boolean, mode: string) {
+export function getGlobalVariables(dev: boolean, buildType: BuildType) {
+  const isDevServerMode = dev && buildType === 'serve';
   return [
     `var __BUNDLE_START_TIME__=globalThis.nativePerformanceNow?nativePerformanceNow():Date.now();`,
     `var __DEV__=${dev};`,
     `var ${GLOBAL_IDENTIFIER}=typeof globalThis!=='undefined'?globalThis:typeof global !== 'undefined'?global:typeof window!=='undefined'?window:this;`,
     `var process=globalThis.process||{};process.env=process.env||{};process.env.NODE_ENV=process.env.NODE_ENV||"${dev ? 'development' : 'production'}";`,
-    dev && mode === 'serve' ? `var $RefreshReg$ = () => {};` : null,
-    dev && mode === 'serve' ? `var $RefreshSig$ = () => (v) => v;` : null,
+    isDevServerMode ? `var $RefreshReg$ = () => {};` : null,
+    isDevServerMode ? `var $RefreshSig$ = () => (v) => v;` : null,
   ].filter(isNotNil);
 }

--- a/packages/rollipop/src/node/commands/bundle/index.ts
+++ b/packages/rollipop/src/node/commands/bundle/index.ts
@@ -53,6 +53,7 @@ export const command = new Command('bundle')
     const cwd = process.cwd();
     const config = await Rollipop.loadConfig({
       cwd,
+      mode: 'production',
       configFile: options.config,
       context: { command: 'bundle' },
     });

--- a/packages/rollipop/src/node/commands/start/index.ts
+++ b/packages/rollipop/src/node/commands/start/index.ts
@@ -36,6 +36,7 @@ export const command = new Command('start')
     const cwd = process.cwd();
     const config = await Rollipop.loadConfig({
       cwd,
+      mode: 'development',
       configFile: options.config,
       context: { command: 'start' },
     });

--- a/packages/rollipop/src/testing/config.ts
+++ b/packages/rollipop/src/testing/config.ts
@@ -6,6 +6,7 @@ import type { Config, ResolvedConfig } from '../config';
 import {
   DEFAULT_ASSET_EXTENSIONS,
   DEFAULT_ASSET_REGISTRY_PATH,
+  DEFAULT_ENV_PREFIX,
   DEFAULT_RESOLVER_CONDITION_NAMES,
   DEFAULT_RESOLVER_MAIN_FIELDS,
   DEFAULT_SOURCE_EXTENSIONS,
@@ -15,6 +16,7 @@ import type { Reporter } from '../types';
 export function createTestConfig(basePath: string): ResolvedConfig {
   const defaultConfig = {
     root: basePath,
+    mode: 'development',
     entry: 'index.js',
     resolver: {
       sourceExtensions: DEFAULT_SOURCE_EXTENSIONS,
@@ -62,6 +64,8 @@ export function createTestConfig(basePath: string): ResolvedConfig {
       status: process.stderr.isTTY ? 'progress' : 'compat',
     },
     reporter: { update: noop } as Reporter,
+    envDir: basePath,
+    envPrefix: DEFAULT_ENV_PREFIX,
   } satisfies Config;
 
   return defaultConfig;

--- a/packages/rollipop/src/utils/build-options.ts
+++ b/packages/rollipop/src/utils/build-options.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import { merge } from 'es-toolkit';
 
+import type { ResolvedConfig } from '../config';
 import type { BuildOptions } from '../core/types';
 
 const DEFAULT_BUILD_OPTIONS = {
@@ -10,16 +11,16 @@ const DEFAULT_BUILD_OPTIONS = {
   minify: false,
 } satisfies Partial<BuildOptions>;
 
-export function resolveBuildOptions(projectRoot: string, buildOptions: BuildOptions) {
+export function resolveBuildOptions(config: ResolvedConfig, buildOptions: BuildOptions) {
   if (buildOptions.outfile) {
-    buildOptions.outfile = path.resolve(projectRoot, buildOptions.outfile);
+    buildOptions.outfile = path.resolve(config.root, buildOptions.outfile);
   }
 
   if (buildOptions.sourcemap) {
-    buildOptions.sourcemap = path.resolve(projectRoot, buildOptions.sourcemap);
+    buildOptions.sourcemap = path.resolve(config.root, buildOptions.sourcemap);
   }
 
-  return merge(DEFAULT_BUILD_OPTIONS, buildOptions);
+  return merge(DEFAULT_BUILD_OPTIONS, { dev: config.mode === 'development', ...buildOptions });
 }
 
 export type ResolvedBuildOptions = ReturnType<typeof resolveBuildOptions>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8789,6 +8789,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv-expand@npm:^12.0.3":
+  version: 12.0.3
+  resolution: "dotenv-expand@npm:12.0.3"
+  dependencies:
+    dotenv: "npm:^16.4.5"
+  checksum: 10c0/0824bdc74fc816a28b0744b7853a23e046602e9616c82121dfdae21ebc13c6e89afeb773e794e97c35d48be2be0a990fbca721ee3869a49c04210a58a3cf296f
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.4.5":
+  version: 16.6.1
+  resolution: "dotenv@npm:16.6.1"
+  checksum: 10c0/15ce56608326ea0d1d9414a5c8ee6dcf0fffc79d2c16422b4ac2268e7e2d76ff5a572d37ffe747c377de12005f14b3cc22361e79fc7f1061cce81f77d2c973dc
+  languageName: node
+  linkType: hard
+
 "dotenv@npm:^17.2.3":
   version: 17.2.3
   resolution: "dotenv@npm:17.2.3"
@@ -14985,6 +15001,8 @@ __metadata:
     commander: "npm:^14.0.2"
     dayjs: "npm:^1.11.19"
     dedent: "npm:^1.7.1"
+    dotenv: "npm:^17.2.3"
+    dotenv-expand: "npm:^12.0.3"
     es-toolkit: "catalog:"
     fastify: "npm:^5.6.2"
     fastify-plugin: "npm:^5.1.0"


### PR DESCRIPTION
# Description 

[Similar to Vite](https://vite.dev/guide/env-and-mode.html#env-files), this adds a `dotenv` based environment variable loading feature to the core functionality.

`.env` files are loaded in the following order, with later files overriding earlier ones:

- `.env` (lowest priority)
- `.env.local`
- `.env.[mode]`
- `.env.[mode].local` (highest priority)

(mode value can be 'development' or 'production')

The defined environment variables can be accessed through `import.meta.env.ENV_NAME` expressions:

```ts
console.log(import.meta.env.ROLLIPOP_DESCRIPTION);
```

Type definitions are handled as follows:

```ts
// e.g, rollipop.d.ts
/// <reference types="rollipop/client" />

interface ImportMetaEnv {
  readonly ROLLIPOP_DESCRIPTION: string;
}

interface ImportMeta {
  readonly env: ImportMetaEnv;
}
```

<img width="537" height="80" alt="image" src="https://github.com/user-attachments/assets/6942a350-3c99-4b0a-a45a-07d026cb2624" />

