### PR TITLE
feat(hmr): improve compatibility for lower runtime versions

### DIFF
--- a/.changeset/shaggy-rules-guess.md
+++ b/.changeset/shaggy-rules-guess.md
@@ -1,0 +1,5 @@
+---
+"rollipop": patch
+---
+
+improve HRM runtime compatibility for lower runtime versions

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3096,12 +3096,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  fast_float: 914e00b8b67cb8ba184a778c7bbc2e9fe98d37b3
+  fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: a293a88992c4c33f0aee184acab0b64a08ff9458
-  fmt: b85d977e8fe789fd71c77123f9f4920d88c4d170
-  glog: 682871fb30f4a65f657bf357581110656ea90b08
-  hermes-engine: fc3729f77ec3f3192fc6d56a2f90baf3f8c8edca
-  RCT-Folly: fb64616e25cfac1c3d10bfd784d68926325ae67f
+  fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
+  hermes-engine: 557a45e3d5ad5fa113377f7e5719249e9fb578d1
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: 2b70c6e3abe00396cefd8913efbf6a2db01a2b36
   RCTRequired: f3540eee8094231581d40c5c6d41b0f170237a81
   RCTSwiftUI: 5928f7ca7e9e2f1a82d85d4c79ea3065137ad81c

--- a/packages/rollipop/src/runtime/dev-runtime-fallback.ts
+++ b/packages/rollipop/src/runtime/dev-runtime-fallback.ts
@@ -1,0 +1,124 @@
+/**
+ * Ported from:
+ * @see https://github.com/rolldown/rolldown/blob/v1.0.0-beta.59/crates/rolldown_plugin_hmr/src/runtime/runtime-extra-dev-common.js
+ */
+
+import type { HMRClientMessage } from '../types/hmr';
+import { __exportAll$, __reExport$, __toCommonJS$, __toESM$ } from './runtime-utils';
+
+export interface Messenger {
+  send(message: HMRClientMessage): void;
+}
+
+export interface DevRuntime {
+  modules: Record<string, ModuleFallback>;
+  createModuleHotContext(moduleId: string): void;
+  applyUpdates(boundaries: [string, string][]): void;
+  registerModule(id: string, exportsHolder: ModuleFallback['exportsHolder']): void;
+  loadExports(id: string): void;
+}
+
+export class ModuleFallback {
+  exportsHolder: { exports: any } = { exports: null };
+  id: string;
+
+  constructor(id: string) {
+    this.id = id;
+  }
+
+  get exports() {
+    return this.exportsHolder.exports;
+  }
+}
+
+/**
+ * @typedef {{ type: 'hmr:module-registered', modules: string[] }} DevRuntimeMessage
+ * @typedef {{ send(message: DevRuntimeMessage): void }} Messenger
+ */
+
+export abstract class DevRuntimeFallback implements DevRuntime {
+  modules: Record<string, ModuleFallback> = {};
+
+  get __toESM() {
+    return __toESM$;
+  }
+
+  get __toCommonJS() {
+    return __toCommonJS$;
+  }
+
+  get __exportAll() {
+    return __exportAll$;
+  }
+
+  get __reExport() {
+    return __reExport$;
+  }
+
+  get __toDynamicImportESM() {
+    return (isNodeMode: boolean) => (mod: any) => __toESM$(mod.default, isNodeMode);
+  }
+
+  constructor(public messenger: Messenger) {}
+
+  abstract createModuleHotContext(moduleId: string): void;
+  abstract applyUpdates(boundaries: [string, string][]): void;
+
+  registerModule(id: string, exportsHolder: ModuleFallback['exportsHolder']) {
+    const module = new ModuleFallback(id);
+    module.exportsHolder = exportsHolder;
+    this.modules[id] = module;
+    this.sendModuleRegisteredMessage(id);
+  }
+
+  loadExports(id: string) {
+    const module = this.modules[id];
+    if (module) {
+      return module.exportsHolder.exports;
+    } else {
+      console.warn(`Module ${id} not found`);
+      return {};
+    }
+  }
+
+  createEsmInitializer =
+    <T>(fn: any, res: T) =>
+    () => (fn && (res = fn((fn = 0))), res);
+
+  createCjsInitializer =
+    <T extends ModuleFallback['exportsHolder']>(cb: any, mod: ModuleFallback['exportsHolder']) =>
+    (): T => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+
+  sendModuleRegisteredMessage = (() => {
+    let timeout: NodeJS.Timeout | null = null;
+    let timeoutSetLength = 0;
+    const cache: string[] = [];
+
+    return (module: string) => {
+      if (!this.messenger) {
+        return;
+      }
+      cache.push(module);
+      if (!timeout) {
+        const flushCache = () => {
+          if (cache.length > timeoutSetLength) {
+            timeout = setTimeout(flushCache);
+            timeoutSetLength = cache.length;
+            return;
+          }
+
+          this.messenger.send({
+            type: 'hmr:module-registered',
+            modules: cache,
+          });
+          cache.length = 0;
+          timeout = null;
+          timeoutSetLength = 0;
+        };
+
+        timeout = setTimeout(flushCache);
+        timeoutSetLength = cache.length;
+      }
+    };
+  })();
+}

--- a/packages/rollipop/src/runtime/hmr-runtime.ts
+++ b/packages/rollipop/src/runtime/hmr-runtime.ts
@@ -7,18 +7,13 @@ import type {
   HMRServerMessage,
 } from '../types/hmr';
 import { HMRContext } from '../types/hmr';
+import {
+  DevRuntimeFallback,
+  type DevRuntime as DevRuntimeInterface,
+  type ModuleFallback,
+  type Messenger,
+} from './dev-runtime-fallback';
 import { enqueueUpdate, isReactRefreshBoundary } from './react-refresh-utils';
-
-interface Messenger {
-  send(message: HMRClientMessage): void;
-}
-
-interface Module {
-  (id: string): Module;
-  id: string;
-  exportsHolder: { exports: any };
-  exports: any;
-}
 
 declare global {
   var __rolldown_runtime__: ReactNativeDevRuntime;
@@ -28,20 +23,34 @@ declare global {
   var __ReactRefresh: any;
 }
 
-declare class DevRuntime {
-  constructor(messenger: Messenger);
-  modules: Record<string, Module>;
-  createModuleHotContext(moduleId: string): void;
-  applyUpdates(boundaries: [string, string][]): void;
-  registerModule(id: string, exportsHolder: Module['exportsHolder']): void;
-  loadExports(id: string): void;
-}
-
 declare global {
   var __ROLLIPOP_CUSTOM_HMR_HANDLER__: HMRCustomHandler | undefined;
 }
 
-var BaseDevRuntime = DevRuntime;
+// DO NOT EDIT THIS CLASS NAME (`DevRuntime`)
+declare class DevRuntime implements DevRuntimeInterface {
+  constructor(messenger: Messenger);
+  modules: Record<string, ModuleFallback>;
+  createModuleHotContext(moduleId: string): void;
+  applyUpdates(boundaries: [string, string][]): void;
+  registerModule(id: string, exportsHolder: ModuleFallback['exportsHolder']): void;
+  loadExports(id: string): void;
+}
+
+/**
+ * Rolldown injects the `rolldown:hmr` virtual module into the entry module,
+ * which contains the HMR Runtime class implementation (class name: `DevRuntime`).
+ *
+ * However, while Hermes V1 supports `class` syntax, earlier versions of the Hermes runtime do not, making this implementation unusable.
+ * Interestingly, Hermes evaluates class syntax as `null` instead of throwing a syntax error,
+ * which allows us to safely replace the implementation using the nullish coalescing operator.
+ *
+ * Therefore, when DevRuntime injected by Rolldown is unavailable (i.e., in non-Hermes V1 environments),
+ * we use an ES5-transpiled fallback implementation instead to work around this and prevent runtime errors.
+ *
+ * @see https://github.com/rolldown/rolldown/blob/feae112db77bf01e886b859e347ce3256944d360/crates/rolldown_plugin_hmr/src/hmr_plugin.rs#L66
+ */
+var BaseDevRuntime = DevRuntime ?? DevRuntimeFallback;
 
 class ModuleHotContext implements HMRContext {
   private readonly removeListeners: (() => void)[] = [];

--- a/packages/rollipop/src/runtime/runtime-utils.ts
+++ b/packages/rollipop/src/runtime/runtime-utils.ts
@@ -1,0 +1,56 @@
+/**
+ * Ported from:
+ * @see https://github.com/rolldown/rolldown/blob/feae112db77bf01e886b859e347ce3256944d360/crates/rolldown/src/runtime/runtime-base.js
+ */
+
+export const __create$ = Object.create;
+export const __defProp$ = Object.defineProperty;
+export const __hasOwnProp$ = Object.prototype.hasOwnProperty;
+export const __getProtoOf$ = Object.getPrototypeOf;
+export const __getOwnPropNames$ = Object.getOwnPropertyNames;
+export const __getOwnPropDesc$ = Object.getOwnPropertyDescriptor;
+
+export const __copyProps$ = (to: any, from: any, except?: string, desc?: PropertyDescriptor) => {
+  if ((from && typeof from === 'object') || typeof from === 'function') {
+    for (var keys = __getOwnPropNames$(from), i = 0, n = keys.length, key; i < n; i++) {
+      key = keys[i];
+      if (!__hasOwnProp$.call(to, key) && key !== except) {
+        __defProp$(to, key, {
+          get: ((k: string) => from[k]).bind(null, key),
+          enumerable: !(desc = __getOwnPropDesc$(from, key)) || desc.enumerable,
+        });
+      }
+    }
+  }
+  return to;
+};
+
+export const __toESM$ = (mod: any, isNodeMode: boolean, target?: any) => (
+  (target = mod != null ? __create$(__getProtoOf$(mod)) : {}),
+  __copyProps$(
+    isNodeMode || !mod || !mod.__esModule$
+      ? __defProp$(target, 'default', { value: mod, enumerable: true })
+      : target,
+    mod,
+  )
+);
+
+export const __toCommonJS$ = (mod: any) =>
+  __hasOwnProp$.call(mod, 'module.exports')
+    ? mod['module.exports']
+    : __copyProps$(__defProp$({}, '__esModule', { value: true }), mod);
+
+export const __exportAll$ = (all: any, symbols: boolean) => {
+  let target = {};
+  for (var name in all) {
+    __defProp$(target, name, { get: all[name], enumerable: true });
+  }
+  if (symbols) {
+    __defProp$(target, Symbol.toStringTag, { value: 'Module' });
+  }
+  return target;
+};
+
+export const __reExport$ = (target: any, mod: any, secondTarget: any) => (
+  __copyProps$(target, mod, 'default'), secondTarget && __copyProps$(secondTarget, mod, 'default')
+);

--- a/packages/rollipop/src/runtime/runtime-utils.ts
+++ b/packages/rollipop/src/runtime/runtime-utils.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable */
 /**
  * Ported from:
  * @see https://github.com/rolldown/rolldown/blob/feae112db77bf01e886b859e347ce3256944d360/crates/rolldown/src/runtime/runtime-base.js


### PR DESCRIPTION
# Description

In Hermes (Non Hermes V1), class syntax is not supported, causing parsing errors when the HMR Runtime implementation code is processed.

To address this, a fallback `DevRuntime` implementation transpiled to ES5-compatible syntax has been added to ensure backward compatibility.

| Before | After |
|:---:|:---:|
| <img width="554" height="1052" alt="Screenshot 2026-01-13 at 00 29 30" src="https://github.com/user-attachments/assets/3db0a60e-cd7f-42a0-b56c-f67a8798d6e5" /> | <img width="554" height="1052" alt="image" src="https://github.com/user-attachments/assets/4ccbf95b-8d13-476b-bfe3-927f3a5ecd84" /> |
