### PR TITLE
feat: add `devMode.useFileSystemBundle` for raw bundle debugging

### DIFF
--- a/.changeset/full-aliens-like.md
+++ b/.changeset/full-aliens-like.md
@@ -1,0 +1,5 @@
+---
+"rollipop": patch
+---
+
+add `devMode.useFileSystemBundle` for raw bundle debugging

--- a/packages/rollipop/src/config/types.ts
+++ b/packages/rollipop/src/config/types.ts
@@ -1,8 +1,8 @@
 import type * as babel from '@babel/core';
 import type * as rolldown from '@rollipop/rolldown';
-import type { TransformOptions } from '@rollipop/rolldown/utils';
 import type { TopLevelFilterExpression } from '@rollipop/rolldown-pluginutils';
 import type { DevWatchOptions } from '@rollipop/rolldown/experimental';
+import type { TransformOptions } from '@rollipop/rolldown/utils';
 import type * as swc from '@swc/core';
 
 import type { Plugin } from '../core/plugins/types';
@@ -339,6 +339,15 @@ export interface DevModeConfig {
    * Defaults to `true`.
    */
   hmr?: boolean | HmrConfig;
+  /**
+   * Whether to use file system bundle instead of in-memory bundle.
+   *
+   * When enabled, the bundle will be saved to the file system and loaded from the file system if the file is modified.
+   * This is useful for raw bundle debugging purposes.
+   *
+   * Defaults to: `false`
+   */
+  useFileSystemBundle?: boolean;
 }
 
 export interface HmrConfig {

--- a/packages/rollipop/src/server/bundle.ts
+++ b/packages/rollipop/src/server/bundle.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { invariant } from 'es-toolkit';
 import {
   SourceMapConsumer,
@@ -5,11 +8,19 @@ import {
   type IndexedSourceMapConsumer,
 } from 'source-map';
 
+import { getSharedDataPath } from '../core/fs/data';
+import { logger } from '../logger';
 import { replaceSourceMappingURL } from '../utils/source-map';
 
 type SourceMapConsumerType = BasicSourceMapConsumer | IndexedSourceMapConsumer;
 
-export class InMemoryBundle {
+export interface Bundle {
+  code: string;
+  sourceMap: string | undefined;
+  sourceMapConsumer: Promise<SourceMapConsumerType> | undefined;
+}
+
+export class InMemoryBundle implements Bundle {
   private lazySourceMapConsumer: Promise<SourceMapConsumerType> | null = null;
 
   constructor(
@@ -36,5 +47,64 @@ export class InMemoryBundle {
     }
 
     return this.lazySourceMapConsumer;
+  }
+}
+
+export class FileSystemBundle implements Bundle {
+  private readonly bundleFilePath: string;
+  private holder: { code: string; mtimeMs: number };
+
+  constructor(projectRoot: string, id: string, code: string) {
+    const sharedDataPath = getSharedDataPath(projectRoot);
+    const bundlesPath = path.join(sharedDataPath, 'bundles');
+    const bundleFilePath = path.join(bundlesPath, `${id}.bundle`);
+
+    if (!fs.existsSync(bundlesPath)) {
+      fs.mkdirSync(bundlesPath, { recursive: true });
+    }
+
+    fs.writeFileSync(bundleFilePath, code, { encoding: 'utf-8' });
+    const stats = fs.statSync(bundleFilePath);
+
+    this.bundleFilePath = bundleFilePath;
+    this.holder = {
+      code,
+      mtimeMs: stats.mtimeMs,
+    };
+
+    logger.info(`File system bundle created at ${bundleFilePath}`);
+  }
+
+  private update() {
+    const code = fs.readFileSync(this.bundleFilePath, { encoding: 'utf-8' });
+    const stats = fs.statSync(this.bundleFilePath);
+    this.holder = {
+      code,
+      mtimeMs: stats.mtimeMs,
+    };
+  }
+
+  get code() {
+    if (this.isStale()) {
+      logger.info('File system bundle is stale, updating...');
+      this.update();
+    } else {
+      logger.trace('File system bundle is up to date');
+    }
+    return this.holder.code;
+  }
+
+  get sourceMap() {
+    // FileSystem bundle can be modified. so, we can't return the source map.
+    return undefined;
+  }
+
+  get sourceMapConsumer() {
+    // FileSystem bundle can be modified. so, we can't return the source map consumer.
+    return undefined;
+  }
+
+  isStale() {
+    return this.holder.mtimeMs !== fs.statSync(this.bundleFilePath).mtimeMs;
   }
 }

--- a/packages/rollipop/src/server/bundler-pool.ts
+++ b/packages/rollipop/src/server/bundler-pool.ts
@@ -10,7 +10,7 @@ import { getBaseBundleName } from '../utils/bundle';
 import { bindReporter } from '../utils/config';
 import { normalizeRolldownError } from '../utils/errors';
 import { taskHandler } from '../utils/promise';
-import { InMemoryBundle } from './bundle';
+import { type Bundle, FileSystemBundle, InMemoryBundle } from './bundle';
 import { logger } from './logger';
 import type { ServerOptions } from './types';
 
@@ -44,7 +44,7 @@ export class BundlerDevEngine extends EventEmitter<BundlerDevEngineEventMap> {
   private readonly initializeHandle: ReturnType<typeof taskHandler>;
   private readonly isHmrEnabled: boolean;
   private readonly _id: string;
-  private bundle: InMemoryBundle | null = null;
+  private bundle: Bundle | null = null;
   private buildFailedError: Error | null = null;
   private _devEngine: DevEngine | null = null;
   private _state: 'idle' | 'initializing' | 'ready' = 'idle';
@@ -122,7 +122,9 @@ export class BundlerDevEngine extends EventEmitter<BundlerDevEngineEventMap> {
         } else {
           const output = errorOrResult.output[0];
           const sourceMap = output.map?.toString();
-          this.bundle = new InMemoryBundle(output.code, sourceMap, this.sourceMappingURL);
+          this.bundle = this.config.devMode.useFileSystemBundle
+            ? new FileSystemBundle(this.config.root, this.id, output.code)
+            : new InMemoryBundle(output.code, sourceMap, this.sourceMappingURL);
           this.buildFailedError = null;
           logger.debug('Build completed', {
             bundlerId: this.id,

--- a/packages/rollipop/src/server/symbolicate.ts
+++ b/packages/rollipop/src/server/symbolicate.ts
@@ -2,7 +2,7 @@ import { codeFrameColumns } from '@babel/code-frame';
 import { NullableMappedPosition, SourceMapConsumer } from 'source-map';
 
 import { parseUrl } from '../utils/url';
-import { InMemoryBundle } from './bundle';
+import type { Bundle } from './bundle';
 
 export interface StackFrameInput {
   file?: string;
@@ -62,18 +62,18 @@ const INTERNAL_CALLSITES_REGEX = new RegExp(
 );
 
 export async function symbolicate(
-  bundle: InMemoryBundle,
+  bundle: Bundle,
   stack: StackFrameInput[],
 ): Promise<SymbolicateResult> {
   const sourceMapConsumer = await bundle.sourceMapConsumer;
   const symbolicatedStack = stack
     .filter((frame) => frame.file?.startsWith('http'))
-    .map((frame) => originalPositionFor(sourceMapConsumer, frame))
+    .map((frame) => (sourceMapConsumer ? originalPositionFor(sourceMapConsumer, frame) : frame))
     .map((frame) => collapseFrame(frame));
 
   return {
     stack: symbolicatedStack,
-    codeFrame: getCodeFrame(sourceMapConsumer, symbolicatedStack, bundle),
+    codeFrame: getCodeFrame(symbolicatedStack, bundle, sourceMapConsumer),
   };
 }
 
@@ -119,9 +119,9 @@ function convertFrameKey(key: keyof NullableMappedPosition): keyof StackFrameInp
 }
 
 function getCodeFrame(
-  sourceMapConsumer: SourceMapConsumer,
   frames: StackFrameInput[],
-  bundle: InMemoryBundle,
+  bundle: Bundle,
+  sourceMapConsumer?: SourceMapConsumer,
 ): CodeFrame | null {
   const frame = frames.find((frame) => {
     return frame.lineNumber != null && frame.column != null && !isCollapsed(frame);
@@ -134,7 +134,10 @@ function getCodeFrame(
   try {
     const { lineNumber, column, file } = frame;
     const unresolved = file.startsWith('http');
-    const source = unresolved ? bundle.code : sourceMapConsumer.sourceContentFor(frame.file);
+    const source =
+      sourceMapConsumer == null || unresolved
+        ? bundle.code
+        : sourceMapConsumer.sourceContentFor(frame.file);
     const fileName = unresolved ? (parseUrl(file).pathname ?? 'unknown') : file;
     let content = '';
 


### PR DESCRIPTION
# Description

Add `devMode.useFileSystemBundle` option for raw bundle debugging.

**Senario**

1. Trigger build & save bundle into file system

<img width="849" height="147" alt="Screenshot 2026-03-11 at 23 41 15" src="https://github.com/user-attachments/assets/1d49868b-30d2-4803-a92e-58184748b293" />

2. Reload application (Bundle file was not modified)

<img width="453" height="91" alt="Screenshot 2026-03-11 at 23 41 28" src="https://github.com/user-attachments/assets/81874e60-c180-4c26-9a06-3883774ec1a8" />

3. Reload application (Bundle file was modified -> Load file system bundle and serve)

<img width="505" height="97" alt="Screenshot 2026-03-11 at 23 42 02" src="https://github.com/user-attachments/assets/6a3a9895-eebf-4486-9b7f-6a61fd32a9e5" />
