### PR TITLE
fix(docs): align 404 page layout with home and add page title

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -1,8 +1,13 @@
 import SearchDialog from '@/components/search';
 
 import './global.css';
+import type { Metadata } from 'next';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import { Inter } from 'next/font/google';
+
+export const metadata: Metadata = {
+  title: 'Rollipop',
+};
 
 const inter = Inter({
   subsets: ['latin'],

--- a/docs/src/app/not-found.tsx
+++ b/docs/src/app/not-found.tsx
@@ -16,12 +16,12 @@ export default function NotFoundPage() {
       }}
       containerProps={{
         className:
-          '!px-4 pt-4 md:!px-12 md:pt-[42px] lg:pt-[56px] lg:items-center !block [&_[data-sidebar-placeholder]]:!hidden [&_[data-sidebar-panel]]:!hidden',
+          'pt-4 md:pt-[42px] lg:pt-[56px] lg:items-center !block [&_[data-sidebar-placeholder]]:!hidden [&_[data-sidebar-panel]]:!hidden',
       }}
       searchToggle={{ enabled: false }}
       themeSwitch={{ enabled: false }}
     >
-      <div className="flex max-w-[1200px] flex-1 flex-col justify-center gap-4 px-8 pb-[100px] text-center">
+      <div className="mx-auto flex min-h-[calc(100vh-56px)] max-w-[1200px] flex-1 flex-col items-center justify-center gap-4 px-8 text-center">
         <h1 className="mx-auto w-full font-bold text-3xl sm:text-4xl">404</h1>
         <p>Oops! This page seems to have wandered off</p>
         <Link


### PR DESCRIPTION
## Summary
- Fix 404 page navbar spacing mismatch with home page by removing extra container padding (`!px-4 md:!px-12`)
- Vertically center 404 content in the viewport instead of sticking to the top
- Add `metadata` export to root layout so the browser tab title shows "Rollipop"

## Test plan
- [ ] Verify 404 page navbar spacing matches the home page
- [ ] Verify 404 content is vertically centered on screen
- [ ] Verify browser tab title displays "Rollipop"