### PR TITLE
fix(docs): remove `bash` language identifier from package manager command blocks

### DIFF
--- a/docs/content/docs/features/analyze.mdx
+++ b/docs/content/docs/features/analyze.mdx
@@ -7,9 +7,9 @@ The `@rollipop/plugin-analyze` plugin generates an interactive visualization of 
 ## Installation
 
 <Tabs items={['npm', 'pnpm', 'yarn']}>
-  <Tab value="npm">```bash npm install --save-dev @rollipop/plugin-analyze ```</Tab>
-  <Tab value="pnpm">```bash pnpm add -D @rollipop/plugin-analyze ```</Tab>
-  <Tab value="yarn">```bash yarn add -D @rollipop/plugin-analyze ```</Tab>
+  <Tab value="npm">```npm install --save-dev @rollipop/plugin-analyze```</Tab>
+  <Tab value="pnpm">```pnpm add -D @rollipop/plugin-analyze```</Tab>
+  <Tab value="yarn">```yarn add -D @rollipop/plugin-analyze```</Tab>
 </Tabs>
 
 ## Usage

--- a/docs/content/docs/features/dev-server.mdx
+++ b/docs/content/docs/features/dev-server.mdx
@@ -14,9 +14,9 @@ title: Dev Server
 To start the dev server, you can use the `start` command:
 
 <Tabs items={['npm', 'pnpm', 'yarn']}>
-  <Tab value="npm">```bash npm run rollipop start ```</Tab>
-  <Tab value="pnpm">```bash pnpm rollipop start ```</Tab>
-  <Tab value="yarn">```bash yarn rollipop start ```</Tab>
+  <Tab value="npm">```npm run rollipop start```</Tab>
+  <Tab value="pnpm">```pnpm rollipop start```</Tab>
+  <Tab value="yarn">```yarn rollipop start```</Tab>
 </Tabs>
 
 You can customize the dev server with various options:

--- a/docs/content/docs/get-started/quick-start.mdx
+++ b/docs/content/docs/get-started/quick-start.mdx
@@ -22,9 +22,9 @@ You have two options for getting started with Rollipop: using the automated setu
 The quickest way to get started is to use `@rollipop/init`:
 
 <Tabs items={['npm', 'pnpm', 'yarn']}>
-  <Tab value="npm">```bash npx @rollipop/init ```</Tab>
-  <Tab value="pnpm">```bash pnpm dlx @rollipop/init ```</Tab>
-  <Tab value="yarn">```bash yarn dlx @rollipop/init ```</Tab>
+  <Tab value="npm">```npx @rollipop/init```</Tab>
+  <Tab value="pnpm">```pnpm dlx @rollipop/init```</Tab>
+  <Tab value="yarn">```yarn dlx @rollipop/init```</Tab>
 </Tabs>
 
 This command will:
@@ -40,9 +40,9 @@ If you prefer to set up Rollipop manually:
 #### 1. Install the package
 
 <Tabs items={['npm', 'pnpm', 'yarn']}>
-  <Tab value="npm">```bash npm install --save-dev rollipop ```</Tab>
-  <Tab value="pnpm">```bash pnpm add -D rollipop ```</Tab>
-  <Tab value="yarn">```bash yarn add -D rollipop ```</Tab>
+  <Tab value="npm">```npm install --save-dev rollipop```</Tab>
+  <Tab value="pnpm">```pnpm add -D rollipop```</Tab>
+  <Tab value="yarn">```yarn add -D rollipop```</Tab>
 </Tabs>
 
 #### 2. Configure React Native CLI


### PR DESCRIPTION
## Summary

- Remove `bash` language identifier from code blocks inside `<Tab>` components for npm/pnpm/yarn commands
- Prevents "bash" label from appearing in the rendered output

### Changed files
- `docs/content/docs/get-started/quick-start.mdx` — automated/manual install commands (6 Tabs)
- `docs/content/docs/features/analyze.mdx` — plugin install commands (3 Tabs)
- `docs/content/docs/features/dev-server.mdx` — dev server start commands (3 Tabs)

### Note
- Shell command examples in `cli-commands.mdx` and `.env` file examples in `env.mdx` retain `bash` code fences for syntax highlighting purposes