### PR TITLE
fix(core): return cached instance from `FileStorage.getInstance()`

### DIFF
--- a/packages/rollipop/src/core/fs/storage.ts
+++ b/packages/rollipop/src/core/fs/storage.ts
@@ -19,7 +19,7 @@ export class FileStorage {
     if (FileStorage.instance == null) {
       FileStorage.instance = new FileStorage(basePath);
     }
-    return new FileStorage(basePath);
+    return FileStorage.instance;
   }
 
   private constructor(private readonly basePath: string) {


### PR DESCRIPTION
## Summary
- `FileStorage.getInstance()` always returned `new FileStorage(basePath)` instead of the cached static instance, defeating the singleton pattern
- This caused redundant disk I/O on every call and potential data inconsistency between callers
- Fixed by returning `FileStorage.instance` instead

## Test plan
- [ ] Verify `FileStorage.getInstance()` returns the same reference across multiple calls
- [ ] Confirm `.set()` mutations are visible to all callers sharing the singleton