### PR TITLE
fix(server): remove duplicate `hmr:update-done` message

### DIFF
--- a/packages/rollipop/src/server/wss/__tests__/hmr-server.spec.ts
+++ b/packages/rollipop/src/server/wss/__tests__/hmr-server.spec.ts
@@ -173,7 +173,7 @@ describe('HMRServer', () => {
 
       const messages = getSentMessages(testable, client);
       expect(messages).toContainEqual({ type: 'hmr:update', code: 'module.exports = {}' });
-      expect(messages.filter((m) => m.type === 'hmr:update-done')).toHaveLength(2);
+      expect(messages.filter((m) => m.type === 'hmr:update-done')).toHaveLength(1);
     });
   });
 

--- a/packages/rollipop/src/server/wss/hmr-server.ts
+++ b/packages/rollipop/src/server/wss/hmr-server.ts
@@ -161,7 +161,6 @@ export class HMRServer extends WebSocketServer {
     } satisfies HMRServerMessage;
 
     this.send(client, JSON.stringify(updateMessage));
-    this.send(client, JSON.stringify({ type: 'hmr:update-done' }));
     this.done(client);
   }
 


### PR DESCRIPTION
## Summary
- `sendUpdateToClient` sent `hmr:update-done` directly (line 164) and then called `this.done(client)` which sent it again
- Clients received the signal twice per HMR patch update
- Removed the inline send to match the pattern used by `sendReloadToClient`
- Updated test assertion to expect 1 `hmr:update-done` instead of 2

## Test plan
- [x] All 174 tests pass
- [x] Lint passes with 0 warnings