### PR TITLE
feat(server): add SSE event stream and control API

### DIFF
--- a/docs/content/docs/features/meta.json
+++ b/docs/content/docs/features/meta.json
@@ -9,6 +9,7 @@
     "analyze",
     "reanimated-worklets",
     "reporter",
+    "sse",
     "custom-command"
   ],
   "defaultOpen": true

--- a/docs/content/docs/features/sse.mdx
+++ b/docs/content/docs/features/sse.mdx
@@ -1,0 +1,156 @@
+---
+title: Server-Sent Events
+---
+
+The dev server exposes a Server-Sent Events (SSE) endpoint that streams bundler state in real-time. This is useful for integrating with external tools such as LLMs, CI dashboards, or custom monitoring.
+
+## SSE Endpoint
+
+```
+GET /sse/events
+```
+
+The endpoint returns a `text/event-stream` response. Each event is formatted as:
+
+```
+event: <event_type>
+data: <json_payload>
+```
+
+### Event Types
+
+#### `bundle_build_started`
+
+Emitted when a bundle build starts.
+
+```json
+{ "type": "bundle_build_started", "id": "ios-true" }
+```
+
+#### `bundle_build_done`
+
+Emitted when a bundle build completes successfully.
+
+```json
+{ "type": "bundle_build_done", "id": "ios-true", "totalModules": 1270, "duration": 1523.45 }
+```
+
+#### `bundle_build_failed`
+
+Emitted when a bundle build fails.
+
+```json
+{ "type": "bundle_build_failed", "id": "ios-true", "error": "SyntaxError: Unexpected token" }
+```
+
+#### `watch_change`
+
+Emitted when a file change is detected.
+
+```json
+{ "type": "watch_change", "id": "ios-true", "file": "src/App.tsx" }
+```
+
+#### `client_log`
+
+Emitted when the app logs to the console.
+
+```json
+{ "type": "client_log", "data": ["Hello from the app"] }
+```
+
+#### `device_connected` / `device_disconnected`
+
+Emitted when a device connects or disconnects via HMR.
+
+```json
+{ "type": "device_connected", "clientId": 0 }
+```
+
+#### `server_ready`
+
+Emitted once when the dev server is ready.
+
+```json
+{ "type": "server_ready", "host": "localhost", "port": 8081 }
+```
+
+#### `cache_reset`
+
+Emitted when the control API clears the build cache.
+
+```json
+{ "type": "cache_reset" }
+```
+
+### Bundler ID
+
+Events that originate from the bundler include an `id` field. This identifies the specific bundler instance, since multiple instances can run simultaneously for different configurations:
+
+- `ios-true` — iOS, development mode
+- `android-true` — Android, development mode
+- `ios-false` — iOS, production mode
+
+## Control API
+
+The dev server also provides an HTTP endpoint to trigger actions externally.
+
+### `ALL /reset-cache`
+
+Clears the entire build cache.
+
+```
+curl http://localhost:8081/reset-cache
+```
+
+## Usage Examples
+
+### curl
+
+```bash
+# Stream events
+curl -N http://localhost:8081/sse/events
+
+# Reset cache
+curl http://localhost:8081/reset-cache
+```
+
+### Node.js
+
+```ts
+import http from 'node:http';
+
+const req = http.get(
+  'http://localhost:8081/sse/events',
+  { headers: { Accept: 'text/event-stream' } },
+  (res) => {
+    res.setEncoding('utf8');
+    res.on('data', (chunk) => {
+      for (const message of chunk.split('\n\n')) {
+        if (!message.trim() || message.startsWith(':')) continue;
+
+        let event = '';
+        let data = '';
+        for (const line of message.split('\n')) {
+          if (line.startsWith('event: ')) event = line.slice(7);
+          if (line.startsWith('data: ')) data = line.slice(6);
+        }
+
+        if (event && data) {
+          console.log(event, JSON.parse(data));
+        }
+      }
+    });
+  },
+);
+```
+
+### LLM Integration
+
+An LLM agent can observe bundler state via SSE to decide when to proceed:
+
+1. Connect to `GET /sse/events`
+2. Make code changes
+3. Wait for `watch_change` → `bundle_build_started` → `bundle_build_done` or `bundle_build_failed`
+4. If failed, read the error and fix the code
+5. If needed, trigger `POST /reset-cache` to clear stale cache

--- a/example/package.json
+++ b/example/package.json
@@ -6,6 +6,7 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",
+    "start:sse": "node --import @oxc-node/core/register sse-client.mts",
     "test": "jest"
   },
   "dependencies": {
@@ -27,6 +28,7 @@
     "@babel/preset-env": "^7.25.3",
     "@babel/preset-typescript": "^7.28.5",
     "@babel/runtime": "^7.25.0",
+    "@oxc-node/core": "^0.1.0",
     "@react-native-community/cli": "20.1.0",
     "@react-native-community/cli-platform-android": "20.1.0",
     "@react-native-community/cli-platform-ios": "20.1.0",
@@ -41,6 +43,7 @@
     "@types/react": "^19.2.14",
     "@types/react-test-renderer": "^19.1.0",
     "jest": "^29.6.3",
+    "picocolors": "^1.1.1",
     "prettier": "2.8.8",
     "react-native-svg-transformer": "^1.5.3",
     "react-test-renderer": "19.2.3",

--- a/example/sse-client.mts
+++ b/example/sse-client.mts
@@ -1,0 +1,130 @@
+/**
+ * Rollipop SSE Client Example
+ *
+ * Connects to the rollipop dev server's SSE endpoint and prints
+ * bundler events to the terminal in real-time.
+ *
+ * Usage:
+ *   node --import @oxc-node/core/register example/sse-client.mts
+ *   node --import @oxc-node/core/register example/sse-client.mts 8082
+ *   node --import @oxc-node/core/register example/sse-client.mts 8081 192.168.0.1
+ *
+ * Control API:
+ *   curl http://localhost:8081/rebuild
+ *   curl http://localhost:8081/rebuild?platform=ios
+ *   curl http://localhost:8081/reset-cache
+ */
+
+import http from 'node:http';
+
+import pc from 'picocolors';
+
+import type { SSEEvent } from '../packages/rollipop/src/server/sse/types';
+
+const port = Number(process.argv[2] || '8081');
+const host = process.argv[3] || 'localhost';
+const url = `http://${host}:${port}/sse/events`;
+
+const EVENT_STYLES: Record<SSEEvent['type'], { label: string; color: (s: string) => string }> = {
+  server_ready: { label: 'ready', color: pc.green },
+  bundle_build_started: { label: 'build:start', color: pc.blue },
+  bundle_build_done: { label: 'build:done', color: pc.green },
+  bundle_build_failed: { label: 'build:fail', color: pc.red },
+  watch_change: { label: 'watch', color: pc.yellow },
+  client_log: { label: 'log', color: pc.cyan },
+  hmr_update: { label: 'hmr:update', color: pc.magenta },
+  hmr_reload: { label: 'hmr:reload', color: pc.magenta },
+  device_connected: { label: 'device:on', color: pc.green },
+  device_disconnected: { label: 'device:off', color: pc.red },
+  cache_reset: { label: 'cache:reset', color: pc.yellow },
+  symbolicate_request: { label: 'sym:req', color: pc.cyan },
+  symbolicate_result: { label: 'sym:res', color: pc.cyan },
+};
+
+function timestamp(): string {
+  return pc.dim(new Date().toLocaleTimeString('en-GB', { hour12: false }));
+}
+
+function formatEvent(eventType: string, data: SSEEvent): string {
+  const style = EVENT_STYLES[eventType as SSEEvent['type']] ?? {
+    label: eventType,
+    color: pc.gray,
+  };
+  const { type: _, ...rest } = data;
+  const detail = Object.keys(rest).length > 0 ? ` ${pc.dim(JSON.stringify(rest))}` : '';
+  return `${timestamp()} ${style.color(style.label)}${detail}`;
+}
+
+function handleSSEChunk(chunk: string): string {
+  const messages = chunk.split('\n\n');
+  const remaining = messages.pop() || '';
+
+  for (const message of messages) {
+    if (!message.trim() || message.startsWith(':')) continue;
+
+    let eventType = '';
+    let data = '';
+
+    for (const line of message.split('\n')) {
+      if (line.startsWith('event: ')) eventType = line.slice(7);
+      if (line.startsWith('data: ')) data = line.slice(6);
+    }
+
+    if (!eventType || !data) continue;
+
+    try {
+      const parsed = JSON.parse(data) as SSEEvent;
+      console.log(formatEvent(eventType, parsed));
+    } catch {
+      console.log(`${timestamp()} ${pc.dim(`[raw] ${data}`)}`);
+    }
+  }
+
+  return remaining;
+}
+
+function connect(): void {
+  console.log(`${timestamp()} Connecting to ${pc.cyan(url)}...`);
+  console.log(`${timestamp()} ${pc.dim('Press Ctrl+C to exit')}`);
+  console.log();
+
+  const req = http.get(
+    { hostname: host, port, path: '/sse/events', headers: { Accept: 'text/event-stream' } },
+    (res) => {
+      if (res.statusCode !== 200) {
+        console.error(`${timestamp()} ${pc.red(`HTTP ${res.statusCode}: ${res.statusMessage}`)}`);
+        retry();
+        return;
+      }
+
+      console.log(`${timestamp()} ${pc.green('Connected')}`);
+      console.log();
+
+      let buffer = '';
+
+      res.setEncoding('utf8');
+      res.on('data', (chunk: string) => {
+        buffer += chunk;
+        buffer = handleSSEChunk(buffer);
+      });
+
+      res.on('end', () => {
+        console.log();
+        console.log(`${timestamp()} ${pc.yellow('Connection closed')}`);
+        retry();
+      });
+    },
+  );
+
+  req.on('error', (error) => {
+    console.error(`${timestamp()} ${pc.red(`Connection failed: ${error.message}`)}`);
+    retry();
+  });
+}
+
+function retry(): void {
+  console.log(`${timestamp()} ${pc.dim('Reconnecting in 3s...')}`);
+  setTimeout(connect, 3000);
+}
+
+connect();

--- a/packages/rollipop/src/server/__tests__/bundler-pool.spec.ts
+++ b/packages/rollipop/src/server/__tests__/bundler-pool.spec.ts
@@ -8,7 +8,9 @@ vitest.mock('../../core/bundler', () => ({
     createId: vi.fn((_config: any, opts: any) => `${opts.platform}-${opts.dev}`),
     devEngine: vi.fn().mockResolvedValue({
       run: vi.fn().mockResolvedValue(undefined),
-      getBundleState: vi.fn().mockResolvedValue({ lastFullBuildFailed: false, hasStaleOutput: false }),
+      getBundleState: vi
+        .fn()
+        .mockResolvedValue({ lastFullBuildFailed: false, hasStaleOutput: false }),
     }),
   },
 }));

--- a/packages/rollipop/src/server/__tests__/control.spec.ts
+++ b/packages/rollipop/src/server/__tests__/control.spec.ts
@@ -1,0 +1,108 @@
+// oxlint-disable typescript-eslint(unbound-method)
+import fs from 'node:fs';
+
+import type { Mock } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi, vitest } from 'vite-plus/test';
+
+import type { SSEEventBus } from '../sse/event-bus';
+
+vitest.mock('../logger', () => ({
+  logger: {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vitest.mock('../../core/fs/data', () => ({
+  getSharedDataPath: (basePath: string) => `${basePath}/.rollipop`,
+}));
+
+interface MockEventBus {
+  emit: Mock;
+}
+
+function createMockEventBus(): MockEventBus {
+  return { emit: vi.fn() };
+}
+
+interface MockRoute {
+  method: string;
+  path: string;
+  handler: (request: unknown, reply: MockReply) => Promise<unknown>;
+}
+
+interface MockReply {
+  send: Mock;
+}
+
+function createMockReply(): MockReply {
+  return { send: vi.fn().mockReturnThis() };
+}
+
+type PluginFn = (
+  fastify: unknown,
+  options: { projectRoot: string; eventBus: unknown },
+  done: () => void,
+) => void;
+
+function registerControlRoutes(projectRoot: string, eventBus: MockEventBus) {
+  const routes: MockRoute[] = [];
+  const fastify = {
+    all(path: string, handler: MockRoute['handler']) {
+      routes.push({ method: 'all', path, handler });
+    },
+  };
+
+  (control as PluginFn)(
+    fastify,
+    { projectRoot, eventBus: eventBus as unknown as SSEEventBus },
+    () => {},
+  );
+
+  return routes;
+}
+
+const { control } = await import('../middlewares/control');
+
+describe('control plugin', () => {
+  let eventBus: MockEventBus;
+  const projectRoot = '/project';
+
+  beforeEach(() => {
+    eventBus = createMockEventBus();
+    vi.spyOn(fs, 'rmSync').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should register /reset-cache route only', () => {
+    const routes = registerControlRoutes(projectRoot, eventBus);
+    const paths = routes.map((r) => r.path);
+
+    expect(paths).toContain('/reset-cache');
+    expect(paths).not.toContain('/rebuild');
+  });
+
+  it('/reset-cache should clear cache directory and emit event', async () => {
+    const routes = registerControlRoutes(projectRoot, eventBus);
+    const route = routes.find((r) => r.path === '/reset-cache')!;
+    const reply = createMockReply();
+
+    await route.handler({}, reply);
+
+    expect(fs.rmSync).toHaveBeenCalledWith('/project/.rollipop/cache', {
+      recursive: true,
+      force: true,
+    });
+    expect(eventBus.emit).toHaveBeenCalledWith({ type: 'cache_reset' });
+    expect(reply.send).toHaveBeenCalledWith({
+      success: true,
+      message: 'Cache cleared',
+    });
+  });
+});

--- a/packages/rollipop/src/server/__tests__/symbolicate.spec.ts
+++ b/packages/rollipop/src/server/__tests__/symbolicate.spec.ts
@@ -20,10 +20,7 @@ function createMockSourceMapConsumer(mappings: Map<string, any>) {
   };
 }
 
-function createMockBundleStore(
-  sourceMapConsumer: any,
-  code = 'var x = 1;',
-): BundleStore {
+function createMockBundleStore(sourceMapConsumer: any, code = 'var x = 1;'): BundleStore {
   return {
     code,
     sourceMap: '{}',

--- a/packages/rollipop/src/server/bundler-pool.ts
+++ b/packages/rollipop/src/server/bundler-pool.ts
@@ -8,6 +8,7 @@ import { getBundleStoreMode } from '../common/env';
 import type { ResolvedConfig } from '../config';
 import { Bundler } from '../core/bundler';
 import type { BuildOptions, DevEngine } from '../core/types';
+import type { ReportableEvent } from '../types';
 import { getBaseBundleName } from '../utils/bundle';
 import { bindReporter } from '../utils/config';
 import { normalizeRolldownError } from '../utils/errors';
@@ -55,6 +56,7 @@ export class BundlerDevEngine extends EventEmitter<BundlerDevEngineEventMap> {
     private readonly options: BundlerDevEngineOptions,
     private readonly config: ResolvedConfig,
     private readonly buildOptions: BuildOptions,
+    private readonly onReporterEvent?: (id: string, event: ReportableEvent) => void,
   ) {
     super();
     this._id = Bundler.createId(config, buildOptions);
@@ -91,48 +93,56 @@ export class BundlerDevEngine extends EventEmitter<BundlerDevEngineEventMap> {
 
     this._state = 'initializing';
 
-    const devEngine = await Bundler.devEngine(bindReporter(this.config, this), this.buildOptions, {
-      host: this.options.server.host,
-      port: this.options.server.port,
-      onHmrUpdates: (errorOrResult) => {
-        if (!this.isHmrEnabled) {
-          return;
-        }
+    const onEvent = this.onReporterEvent
+      ? (event: ReportableEvent) => this.onReporterEvent!(this._id, event)
+      : undefined;
 
-        if (errorOrResult instanceof Error) {
-          logger.error('Failed to handle HMR updates', {
-            bundlerId: this.id,
-            error: errorOrResult,
-          });
-          const normalizedError = normalizeRolldownError(errorOrResult);
-          this.emit('buildFailed', normalizedError);
-        } else {
-          logger.trace('Detected changed files', {
-            bundlerId: this.id,
-            changedFiles: errorOrResult.changedFiles,
-          });
-          this.emit('hmrUpdates', errorOrResult.updates);
-        }
+    const devEngine = await Bundler.devEngine(
+      bindReporter(this.config, this, onEvent),
+      this.buildOptions,
+      {
+        host: this.options.server.host,
+        port: this.options.server.port,
+        onHmrUpdates: (errorOrResult) => {
+          if (!this.isHmrEnabled) {
+            return;
+          }
+
+          if (errorOrResult instanceof Error) {
+            logger.error('Failed to handle HMR updates', {
+              bundlerId: this.id,
+              error: errorOrResult,
+            });
+            const normalizedError = normalizeRolldownError(errorOrResult);
+            this.emit('buildFailed', normalizedError);
+          } else {
+            logger.trace('Detected changed files', {
+              bundlerId: this.id,
+              changedFiles: errorOrResult.changedFiles,
+            });
+            this.emit('hmrUpdates', errorOrResult.updates);
+          }
+        },
+        onOutput: (errorOrResult) => {
+          if (errorOrResult instanceof Error) {
+            const normalizedError = normalizeRolldownError(errorOrResult);
+            logger.trace('onOutput', { bundlerId: this.id });
+            logger.error(errorOrResult.message);
+            this.buildFailedError = normalizedError;
+            this.emit('buildFailed', normalizedError);
+          } else {
+            const output = errorOrResult.output[0];
+            this.updateBundleStore(output);
+            this.buildFailedError = null;
+            logger.debug('Build completed', {
+              bundlerId: this.id,
+              bundleName: output.name,
+            });
+          }
+        },
+        rebuildStrategy: 'auto',
       },
-      onOutput: (errorOrResult) => {
-        if (errorOrResult instanceof Error) {
-          const normalizedError = normalizeRolldownError(errorOrResult);
-          logger.trace('onOutput', { bundlerId: this.id });
-          logger.error(errorOrResult.message);
-          this.buildFailedError = normalizedError;
-          this.emit('buildFailed', normalizedError);
-        } else {
-          const output = errorOrResult.output[0];
-          this.updateBundleStore(output);
-          this.buildFailedError = null;
-          logger.debug('Build completed', {
-            bundlerId: this.id,
-            bundleName: output.name,
-          });
-        }
-      },
-      rebuildStrategy: 'auto',
-    });
+    );
 
     await devEngine.run();
     this._devEngine = devEngine;
@@ -170,6 +180,7 @@ export class BundlerPool {
   constructor(
     private readonly config: ResolvedConfig,
     private readonly resolvedServerOptions: Required<Pick<ServerOptions, 'host' | 'port'>>,
+    private readonly onReporterEvent?: (id: string, event: ReportableEvent) => void,
   ) {}
 
   private instanceKey(bundleName: string, buildOptions: BuildOptions) {
@@ -191,6 +202,7 @@ export class BundlerPool {
         },
         this.config,
         buildOptions,
+        this.onReporterEvent,
       );
       logger.debug('Setting new bundler instance', { key });
       BundlerPool.instances.set(key, instance);

--- a/packages/rollipop/src/server/create-dev-server.ts
+++ b/packages/rollipop/src/server/create-dev-server.ts
@@ -11,15 +11,20 @@ import type { ResolvedConfig } from '../config';
 import { createPluginContext } from '../core/plugins/context';
 import type { Plugin } from '../core/plugins/types';
 import type { AsyncResult, BuildOptions } from '../core/types';
+import type { ReportableEvent } from '../types';
 import { assertDevServerStatus } from '../utils/dev-server';
 import { BundlerPool } from './bundler-pool';
 import { DEFAULT_HOST, DEFAULT_PORT } from './constants';
 import { errorHandler } from './error';
 import { DevServerLogger, logger } from './logger';
+import { control } from './middlewares/control';
 import { requestLogger } from './middlewares/request-logger';
 import { serveAssets } from './middlewares/serve-assets';
 import { serveBundle } from './middlewares/serve-bundle';
+import { sse } from './middlewares/sse';
 import { symbolicate } from './middlewares/symbolicate';
+import { SSEEventBus } from './sse/event-bus';
+import { toSSEEvent } from './sse/reporter';
 import type { DevServer, DevServerEvents, ServerOptions } from './types';
 import { HMRServer } from './wss/hmr-server';
 import { getWebSocketUpgradeHandler } from './wss/server';
@@ -44,7 +49,14 @@ export async function createDevServer(
     disableRequestLogging: true,
   });
 
-  const bundlerPool = new BundlerPool(config, { host, port });
+  const sseEventBus = new SSEEventBus();
+
+  const bundlerPool = new BundlerPool(config, { host, port }, (id, event) => {
+    const sseEvent = toSSEEvent(id, event);
+    if (sseEvent) {
+      sseEventBus.emit(sseEvent);
+    }
+  });
   const getBundler = (bundleName: string, buildOptions: BuildOptions) => {
     return bundlerPool.get(bundleName, merge(options?.buildOptions ?? {}, buildOptions));
   };
@@ -80,15 +92,21 @@ export async function createDevServer(
 
   const hmrServer = new HMRServer({
     bundlerPool,
-    reportEvent: (event) => {
+    reportEvent: (event: ReportableEvent) => {
       reportEvent?.(event);
       config.reporter?.update(event);
     },
   })
-    .on('connection', (client) => emitter.emit('device.connected', { client }))
+    .on('connection', (client) => {
+      emitter.emit('device.connected', { client });
+      sseEventBus.emit({ type: 'device_connected', clientId: client.id });
+    })
     .on('message', (client, data) => emitter.emit('device.message', { client, data }))
     .on('error', (client, error) => emitter.emit('device.error', { client, error }))
-    .on('close', (client) => emitter.emit('device.disconnected', { client }));
+    .on('close', (client) => {
+      emitter.emit('device.disconnected', { client });
+      sseEventBus.emit({ type: 'device_disconnected', clientId: client.id });
+    });
 
   await fastify.register(import('@fastify/middie'));
 
@@ -118,6 +136,8 @@ export async function createDevServer(
     .use(requestLogger)
     .use(communityMiddleware)
     .use(devMiddleware)
+    .register(sse, { eventBus: sseEventBus })
+    .register(control, { projectRoot, eventBus: sseEventBus })
     .register(symbolicate, { getBundler })
     .register(serveBundle, { getBundler })
     .register(serveAssets, {
@@ -139,6 +159,8 @@ export async function createDevServer(
   );
 
   await invokePostConfigureServer();
+
+  sseEventBus.emit({ type: 'server_ready', host, port });
 
   return devServer;
 }

--- a/packages/rollipop/src/server/middlewares/control.ts
+++ b/packages/rollipop/src/server/middlewares/control.ts
@@ -1,0 +1,22 @@
+import fp from 'fastify-plugin';
+
+import { FileSystemCache } from '../../core/cache/file-system-cache';
+import type { SSEEventBus } from '../sse/event-bus';
+
+export interface ControlPluginOptions {
+  projectRoot: string;
+  eventBus: SSEEventBus;
+}
+
+const plugin = fp<ControlPluginOptions>(
+  (fastify, { projectRoot, eventBus }) => {
+    fastify.all('/reset-cache', async (_request, reply) => {
+      FileSystemCache.clearAll(projectRoot);
+      eventBus.emit({ type: 'cache_reset' });
+      return reply.send({ success: true, message: 'Cache cleared' });
+    });
+  },
+  { name: 'control' },
+);
+
+export { plugin as control };

--- a/packages/rollipop/src/server/middlewares/sse.ts
+++ b/packages/rollipop/src/server/middlewares/sse.ts
@@ -1,0 +1,33 @@
+import fp from 'fastify-plugin';
+
+import type { SSEEventBus } from '../sse/event-bus';
+
+export interface SSEPluginOptions {
+  eventBus: SSEEventBus;
+}
+
+const plugin = fp<SSEPluginOptions>(
+  (fastify, { eventBus }) => {
+    fastify.get('/sse/events', (request, reply) => {
+      const res = reply.raw;
+      res.writeHead(200, {
+        Connection: 'keep-alive',
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'X-Accel-Buffering': 'no',
+      });
+
+      // Disable Nagle's algorithm to prevent buffering small writes
+      request.raw.socket.setNoDelay(true);
+
+      // Send initial comment to flush headers and confirm connection
+      res.write(':ok\n\n');
+
+      eventBus.subscribe(res);
+      request.raw.on('close', () => eventBus.unsubscribe(res));
+    });
+  },
+  { name: 'sse' },
+);
+
+export { plugin as sse };

--- a/packages/rollipop/src/server/sse/__tests__/event-bus.spec.ts
+++ b/packages/rollipop/src/server/sse/__tests__/event-bus.spec.ts
@@ -1,0 +1,89 @@
+// oxlint-disable typescript-eslint(unbound-method)
+import { type ServerResponse } from 'node:http';
+
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { SSEEventBus } from '../event-bus';
+import type { SSEEvent } from '../types';
+
+function createMockResponse(): ServerResponse & { chunks: string[] } {
+  const chunks: string[] = [];
+  return {
+    closed: false,
+    write: vi.fn((chunk: string) => {
+      chunks.push(chunk);
+      return true;
+    }),
+    chunks,
+  } as unknown as ServerResponse & { chunks: string[] };
+}
+
+describe('SSEEventBus', () => {
+  let bus: SSEEventBus;
+
+  beforeEach(() => {
+    bus = new SSEEventBus();
+  });
+
+  describe('subscribe / unsubscribe', () => {
+    it('should track client count', () => {
+      const res = createMockResponse();
+
+      expect(bus.clientCount).toBe(0);
+      bus.subscribe(res);
+      expect(bus.clientCount).toBe(1);
+      bus.unsubscribe(res);
+      expect(bus.clientCount).toBe(0);
+    });
+  });
+
+  describe('emit', () => {
+    it('should send SSE-formatted message to all subscribed clients', () => {
+      const res1 = createMockResponse();
+      const res2 = createMockResponse();
+      bus.subscribe(res1);
+      bus.subscribe(res2);
+
+      const event: SSEEvent = { type: 'server_ready', host: 'localhost', port: 8081 };
+      bus.emit(event);
+
+      const expected = `event: server_ready\ndata: ${JSON.stringify(event)}\n\n`;
+      expect(res1.write).toHaveBeenCalledWith(expected);
+      expect(res2.write).toHaveBeenCalledWith(expected);
+    });
+
+    it('should not send to unsubscribed clients', () => {
+      const res = createMockResponse();
+      bus.subscribe(res);
+      bus.unsubscribe(res);
+
+      bus.emit({ type: 'bundle_build_started', id: 'ios-true' });
+
+      expect(res.write).not.toHaveBeenCalled();
+    });
+
+    it('should skip closed connections', () => {
+      const res = createMockResponse();
+      bus.subscribe(res);
+      (res as unknown as { closed: boolean }).closed = true;
+
+      bus.emit({ type: 'bundle_build_started', id: 'ios-true' });
+
+      expect(res.write).not.toHaveBeenCalled();
+    });
+
+    it('should format different event types correctly', () => {
+      const res = createMockResponse();
+      bus.subscribe(res);
+
+      bus.emit({ type: 'bundle_build_done', id: 'ios-true', totalModules: 42, duration: 1500 });
+      bus.emit({ type: 'watch_change', id: 'ios-true', file: 'src/App.tsx' });
+
+      expect(res.chunks).toHaveLength(2);
+      expect(res.chunks[0]).toContain('event: bundle_build_done');
+      expect(res.chunks[0]).toContain('"totalModules":42');
+      expect(res.chunks[1]).toContain('event: watch_change');
+      expect(res.chunks[1]).toContain('"file":"src/App.tsx"');
+    });
+  });
+});

--- a/packages/rollipop/src/server/sse/__tests__/reporter.spec.ts
+++ b/packages/rollipop/src/server/sse/__tests__/reporter.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import type { ReportableEvent } from '../../../types';
+import { toSSEEvent } from '../reporter';
+
+describe('toSSEEvent', () => {
+  const bundlerId = 'ios-true';
+
+  it('should convert bundle_build_started with id', () => {
+    const event: ReportableEvent = { type: 'bundle_build_started' };
+
+    expect(toSSEEvent(bundlerId, event)).toEqual({
+      type: 'bundle_build_started',
+      id: 'ios-true',
+    });
+  });
+
+  it('should convert bundle_build_done with id', () => {
+    const event: ReportableEvent = { type: 'bundle_build_done', totalModules: 100, duration: 500 };
+
+    expect(toSSEEvent(bundlerId, event)).toEqual({
+      type: 'bundle_build_done',
+      id: 'ios-true',
+      totalModules: 100,
+      duration: 500,
+    });
+  });
+
+  it('should serialize Error to string for bundle_build_failed', () => {
+    const event: ReportableEvent = {
+      type: 'bundle_build_failed',
+      error: new Error('SyntaxError: Unexpected token'),
+    };
+
+    expect(toSSEEvent(bundlerId, event)).toEqual({
+      type: 'bundle_build_failed',
+      id: 'ios-true',
+      error: 'SyntaxError: Unexpected token',
+    });
+  });
+
+  it('should return null for transform events', () => {
+    const event: ReportableEvent = {
+      type: 'transform',
+      id: 'src/App.tsx',
+      totalModules: 100,
+      transformedModules: 50,
+    };
+
+    expect(toSSEEvent(bundlerId, event)).toBeNull();
+  });
+
+  it('should convert watch_change with id and rename fields', () => {
+    const event: ReportableEvent = { type: 'watch_change', id: 'src/App.tsx' };
+
+    expect(toSSEEvent(bundlerId, event)).toEqual({
+      type: 'watch_change',
+      id: 'ios-true',
+      file: 'src/App.tsx',
+    });
+  });
+
+  it('should convert client_log without id', () => {
+    const event: ReportableEvent = {
+      type: 'client_log',
+      level: 'error',
+      data: ['Something went wrong'],
+    };
+
+    expect(toSSEEvent(bundlerId, event)).toEqual({
+      type: 'client_log',
+      data: ['Something went wrong'],
+    });
+  });
+});

--- a/packages/rollipop/src/server/sse/event-bus.ts
+++ b/packages/rollipop/src/server/sse/event-bus.ts
@@ -1,0 +1,29 @@
+import type { ServerResponse } from 'node:http';
+
+import type { SSEEvent } from './types';
+
+export class SSEEventBus {
+  private clients: Set<ServerResponse> = new Set();
+
+  emit(event: SSEEvent): void {
+    const data = JSON.stringify(event);
+    const message = `event: ${event.type}\ndata: ${data}\n\n`;
+    for (const client of this.clients) {
+      if (!client.closed) {
+        client.write(message);
+      }
+    }
+  }
+
+  subscribe(res: ServerResponse): void {
+    this.clients.add(res);
+  }
+
+  unsubscribe(res: ServerResponse): void {
+    this.clients.delete(res);
+  }
+
+  get clientCount(): number {
+    return this.clients.size;
+  }
+}

--- a/packages/rollipop/src/server/sse/reporter.ts
+++ b/packages/rollipop/src/server/sse/reporter.ts
@@ -1,0 +1,33 @@
+import stripAnsi from 'strip-ansi';
+
+import type { ReportableEvent } from '../../types';
+import type { SSEEvent } from './types';
+
+export function toSSEEvent(id: string, event: ReportableEvent): SSEEvent | null {
+  switch (event.type) {
+    case 'bundle_build_started':
+      return { type: 'bundle_build_started', id };
+
+    case 'bundle_build_done':
+      return {
+        type: 'bundle_build_done',
+        id,
+        totalModules: event.totalModules,
+        duration: event.duration,
+      };
+
+    case 'bundle_build_failed':
+      return { type: 'bundle_build_failed', id, error: stripAnsi(event.error.message) };
+
+    case 'watch_change':
+      return { type: 'watch_change', id, file: event.id };
+
+    case 'client_log':
+      return { type: 'client_log', data: event.data };
+
+    case 'transform':
+      // Intentionally excluded from SSE — transform fires per module
+      // and would consume excessive LLM tokens.
+      return null;
+  }
+}

--- a/packages/rollipop/src/server/sse/types.ts
+++ b/packages/rollipop/src/server/sse/types.ts
@@ -1,0 +1,23 @@
+import type { StackFrameInput, StackFrameOutput, CodeFrame } from '../symbolicate';
+
+export type SSEEvent =
+  // Build lifecycle events (from reporter pipeline, always have bundler id)
+  | { type: 'bundle_build_started'; id: string }
+  | { type: 'bundle_build_done'; id: string; totalModules: number; duration: number }
+  | { type: 'bundle_build_failed'; id: string; error: string }
+  | { type: 'watch_change'; id: string; file: string }
+  // Client log events (from HMR client)
+  | { type: 'client_log'; data: unknown[] }
+  // HMR events
+  | { type: 'hmr_update'; id: string; platform: string; updatedModules: number }
+  | { type: 'hmr_reload'; id: string; platform: string }
+  // Symbolicate events
+  | { type: 'symbolicate_request'; stack: StackFrameInput[] }
+  | { type: 'symbolicate_result'; stack: StackFrameOutput[]; codeFrame: CodeFrame | null }
+  // Device lifecycle events
+  | { type: 'device_connected'; clientId: number }
+  | { type: 'device_disconnected'; clientId: number }
+  // Server lifecycle events
+  | { type: 'server_ready'; host: string; port: number }
+  // Control API events
+  | { type: 'cache_reset' };

--- a/packages/rollipop/src/server/wss/__tests__/hmr-server.spec.ts
+++ b/packages/rollipop/src/server/wss/__tests__/hmr-server.spec.ts
@@ -47,10 +47,7 @@ vitest.mock('../server', async () => {
  */
 interface TestableHMRServer {
   onMessage(client: WebSocketClient, data: Buffer): void;
-  sendUpdateToClient(
-    client: WebSocketClient,
-    update: { type: string; code?: string },
-  ): void;
+  sendUpdateToClient(client: WebSocketClient, update: { type: string; code?: string }): void;
   sendReloadToClient(client: WebSocketClient): void;
   cleanup(client: WebSocketClient): void;
   send: Mock;

--- a/packages/rollipop/src/utils/config.ts
+++ b/packages/rollipop/src/utils/config.ts
@@ -3,11 +3,12 @@ import fs from 'node:fs';
 
 import type { HmrConfig, ResolvedConfig } from '../config';
 import type { BundlerDevEngineEventMap } from '../server/bundler-pool';
-import type { Reporter } from '../types';
+import type { ReportableEvent, Reporter } from '../types';
 
 export function bindReporter(
   config: ResolvedConfig,
   eventSource: EventEmitter<BundlerDevEngineEventMap>,
+  onEvent?: (event: ReportableEvent) => void,
 ): ResolvedConfig {
   const originalReporter = config.reporter;
   const reporter: Reporter = {
@@ -34,6 +35,7 @@ export function bindReporter(
           break;
       }
       originalReporter?.update(event);
+      onEvent?.(event);
     },
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1997,6 +1997,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@emnapi/core@npm:1.9.1"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.0"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/00e7a99a2bc3ad908ca8272ba861a934da87dffa8797a41316c4a3b571a1e4d2743e2fa14b1a0f131fa4a3c2018ddb601cd2a8cb7f574fa940af696df3c2fe8d
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:^1.4.3, @emnapi/core@npm:^1.7.1":
   version: 1.7.1
   resolution: "@emnapi/core@npm:1.7.1"
@@ -2014,6 +2024,15 @@ __metadata:
     "@emnapi/wasi-threads": "npm:1.2.0"
     tslib: "npm:^2.4.0"
   checksum: 10c0/defbfa5861aa5ff1346dbc6a19df50d727ae76ae276a31a97b178db8eecae0c5179976878087b43ac2441750e40e6c50e465280383256deb16dd2fb167dd515c
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@emnapi/runtime@npm:1.9.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/750edca117e0363ab2de10622f8ee60e57d8690c2f29c49704813da5cd627c641798d7f3cb0d953c62fdc71688e02e333ddbf2c1204f38b47e3e40657332a6f5
   languageName: node
   linkType: hard
 
@@ -3321,6 +3340,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.2"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.1"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10c0/725c30ec9c480a8d0c1a6a4ce31dc6c830365d485e23ad560e143d1cb9db89a0c95fbb5b9d53c07121729817a3683db6f1ab65d7e4f38fa7482a11b15ef6c6fd
+  languageName: node
+  linkType: hard
+
 "@next/env@npm:16.2.1":
   version: 16.2.1
   resolution: "@next/env@npm:16.2.1"
@@ -3598,9 +3629,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-node/core-android-arm-eabi@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-android-arm-eabi@npm:0.1.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@oxc-node/core-android-arm64@npm:0.0.35":
   version: 0.0.35
   resolution: "@oxc-node/core-android-arm64@npm:0.0.35"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-node/core-android-arm64@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-android-arm64@npm:0.1.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -3612,9 +3657,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-node/core-darwin-arm64@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-darwin-arm64@npm:0.1.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@oxc-node/core-darwin-x64@npm:0.0.35":
   version: 0.0.35
   resolution: "@oxc-node/core-darwin-x64@npm:0.0.35"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-node/core-darwin-x64@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-darwin-x64@npm:0.1.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -3626,9 +3685,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-node/core-freebsd-x64@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-freebsd-x64@npm:0.1.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@oxc-node/core-linux-arm-gnueabihf@npm:0.0.35":
   version: 0.0.35
   resolution: "@oxc-node/core-linux-arm-gnueabihf@npm:0.0.35"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-node/core-linux-arm-gnueabihf@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-linux-arm-gnueabihf@npm:0.1.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -3640,9 +3713,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-node/core-linux-arm64-gnu@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-linux-arm64-gnu@npm:0.1.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@oxc-node/core-linux-arm64-musl@npm:0.0.35":
   version: 0.0.35
   resolution: "@oxc-node/core-linux-arm64-musl@npm:0.0.35"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-node/core-linux-arm64-musl@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-linux-arm64-musl@npm:0.1.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -3654,9 +3741,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-node/core-linux-ppc64-gnu@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-linux-ppc64-gnu@npm:0.1.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@oxc-node/core-linux-s390x-gnu@npm:0.0.35":
   version: 0.0.35
   resolution: "@oxc-node/core-linux-s390x-gnu@npm:0.0.35"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-node/core-linux-s390x-gnu@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-linux-s390x-gnu@npm:0.1.0"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -3668,6 +3769,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-node/core-linux-x64-gnu@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-linux-x64-gnu@npm:0.1.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@oxc-node/core-linux-x64-musl@npm:0.0.35":
   version: 0.0.35
   resolution: "@oxc-node/core-linux-x64-musl@npm:0.0.35"
@@ -3675,9 +3783,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-node/core-linux-x64-musl@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-linux-x64-musl@npm:0.1.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@oxc-node/core-openharmony-arm64@npm:0.0.35":
   version: 0.0.35
   resolution: "@oxc-node/core-openharmony-arm64@npm:0.0.35"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-node/core-openharmony-arm64@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-openharmony-arm64@npm:0.1.0"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -3691,9 +3813,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-node/core-wasm32-wasi@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-wasm32-wasi@npm:0.1.0"
+  dependencies:
+    "@emnapi/core": "npm:1.9.1"
+    "@emnapi/runtime": "npm:1.9.1"
+    "@napi-rs/wasm-runtime": "npm:^1.1.2"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
 "@oxc-node/core-win32-arm64-msvc@npm:0.0.35":
   version: 0.0.35
   resolution: "@oxc-node/core-win32-arm64-msvc@npm:0.0.35"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-node/core-win32-arm64-msvc@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-win32-arm64-msvc@npm:0.1.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -3705,9 +3845,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-node/core-win32-ia32-msvc@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-win32-ia32-msvc@npm:0.1.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@oxc-node/core-win32-x64-msvc@npm:0.0.35":
   version: 0.0.35
   resolution: "@oxc-node/core-win32-x64-msvc@npm:0.0.35"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-node/core-win32-x64-msvc@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core-win32-x64-msvc@npm:0.1.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -3770,6 +3924,67 @@ __metadata:
     "@oxc-node/core-win32-x64-msvc":
       optional: true
   checksum: 10c0/6328427d833c99b498f41b8dc58ed3503d17aabe66172a5aacce06c7e85377649aa6ac602dfa5dd8f8f01167b5fe428a65d751c40386eced495acbe9eb414e10
+  languageName: node
+  linkType: hard
+
+"@oxc-node/core@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@oxc-node/core@npm:0.1.0"
+  dependencies:
+    "@oxc-node/core-android-arm-eabi": "npm:0.1.0"
+    "@oxc-node/core-android-arm64": "npm:0.1.0"
+    "@oxc-node/core-darwin-arm64": "npm:0.1.0"
+    "@oxc-node/core-darwin-x64": "npm:0.1.0"
+    "@oxc-node/core-freebsd-x64": "npm:0.1.0"
+    "@oxc-node/core-linux-arm-gnueabihf": "npm:0.1.0"
+    "@oxc-node/core-linux-arm64-gnu": "npm:0.1.0"
+    "@oxc-node/core-linux-arm64-musl": "npm:0.1.0"
+    "@oxc-node/core-linux-ppc64-gnu": "npm:0.1.0"
+    "@oxc-node/core-linux-s390x-gnu": "npm:0.1.0"
+    "@oxc-node/core-linux-x64-gnu": "npm:0.1.0"
+    "@oxc-node/core-linux-x64-musl": "npm:0.1.0"
+    "@oxc-node/core-openharmony-arm64": "npm:0.1.0"
+    "@oxc-node/core-wasm32-wasi": "npm:0.1.0"
+    "@oxc-node/core-win32-arm64-msvc": "npm:0.1.0"
+    "@oxc-node/core-win32-ia32-msvc": "npm:0.1.0"
+    "@oxc-node/core-win32-x64-msvc": "npm:0.1.0"
+    pirates: "npm:^4.0.7"
+  dependenciesMeta:
+    "@oxc-node/core-android-arm-eabi":
+      optional: true
+    "@oxc-node/core-android-arm64":
+      optional: true
+    "@oxc-node/core-darwin-arm64":
+      optional: true
+    "@oxc-node/core-darwin-x64":
+      optional: true
+    "@oxc-node/core-freebsd-x64":
+      optional: true
+    "@oxc-node/core-linux-arm-gnueabihf":
+      optional: true
+    "@oxc-node/core-linux-arm64-gnu":
+      optional: true
+    "@oxc-node/core-linux-arm64-musl":
+      optional: true
+    "@oxc-node/core-linux-ppc64-gnu":
+      optional: true
+    "@oxc-node/core-linux-s390x-gnu":
+      optional: true
+    "@oxc-node/core-linux-x64-gnu":
+      optional: true
+    "@oxc-node/core-linux-x64-musl":
+      optional: true
+    "@oxc-node/core-openharmony-arm64":
+      optional: true
+    "@oxc-node/core-wasm32-wasi":
+      optional: true
+    "@oxc-node/core-win32-arm64-msvc":
+      optional: true
+    "@oxc-node/core-win32-ia32-msvc":
+      optional: true
+    "@oxc-node/core-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/ff306be03088ed33003ed46033b4938bbad198587c4d33dbc21c50f505a8b4e7b027ef740d490f0abea65246891471f00654dda246bfa0656c57317022bc0958
   languageName: node
   linkType: hard
 
@@ -9748,6 +9963,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.25.3"
     "@babel/preset-typescript": "npm:^7.28.5"
     "@babel/runtime": "npm:^7.25.0"
+    "@oxc-node/core": "npm:^0.1.0"
     "@react-native-community/cli": "npm:20.1.0"
     "@react-native-community/cli-platform-android": "npm:20.1.0"
     "@react-native-community/cli-platform-ios": "npm:20.1.0"
@@ -9766,6 +9982,7 @@ __metadata:
     "@types/react": "npm:^19.2.14"
     "@types/react-test-renderer": "npm:^19.1.0"
     jest: "npm:^29.6.3"
+    picocolors: "npm:^1.1.1"
     prettier: "npm:2.8.8"
     react: "npm:19.2.3"
     react-native: "npm:0.84.1"


### PR DESCRIPTION
## Summary

- Add `GET /sse/events` SSE endpoint for real-time bundler state observation (build lifecycle, HMR updates, device events, symbolicate)
- Add `ALL /reset-cache` endpoint to clear build cache and trigger rebuilds
- Primary use case: LLM tooling that needs to observe bundler state and trigger actions

(Left: Bundler, Right: Demo SSE Client)
<img width="1799" height="693" alt="Screenshot 2026-04-06 at 07 00 56" src="https://github.com/user-attachments/assets/e19e76a1-bd8c-46e7-bf66-68a80887e133" />

## Test plan
- [x] All 191 tests pass
- [x] Lint passes with 0 warnings
- [x] Typecheck passes