### PR TITLE
feat(server): add MCP server for LLM agent integration

### DIFF
--- a/docs/content/docs/features/mcp.mdx
+++ b/docs/content/docs/features/mcp.mdx
@@ -1,0 +1,56 @@
+---
+title: MCP Server
+---
+
+The dev server embeds an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server at `/mcp`, allowing LLM agents like Claude Code to interact with the bundler through standard MCP tooling.
+
+## Setup
+
+Add the MCP server to your project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "rollipop": {
+      "type": "http",
+      "url": "http://localhost:8081/mcp"
+    }
+  }
+}
+```
+
+Make sure the dev server is running before starting the LLM agent.
+
+## Available Tools
+
+### `reset_cache`
+
+Clears the entire build cache. The bundler will rebuild from scratch on next file change.
+
+### `get_build_events`
+
+Subscribes to bundler events for a specified duration and returns all collected events.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `duration` | number | 10000 | How long to listen in milliseconds (1000-60000) |
+
+Returns a JSON array of events collected during the listening period. Event types include:
+
+- `bundle_build_started` / `bundle_build_done` / `bundle_build_failed` — build lifecycle
+- `watch_change` — file change detected
+- `client_log` — app console output
+- `device_connected` / `device_disconnected` — device lifecycle
+- `cache_reset` — cache cleared via control API
+
+See [SSE](/docs/features/sse) for the full event type reference.
+
+## LLM Workflow
+
+An LLM agent can use MCP tools to interact with the bundler:
+
+1. Call `get_build_events` to observe bundler state
+2. Make code changes
+3. Call `get_build_events` again to wait for `bundle_build_done` or `bundle_build_failed`
+4. If failed, read the error and fix the code
+5. If needed, call `reset_cache` to clear stale cache

--- a/docs/content/docs/features/meta.json
+++ b/docs/content/docs/features/meta.json
@@ -10,6 +10,7 @@
     "reanimated-worklets",
     "reporter",
     "sse",
+    "mcp",
     "custom-command"
   ],
   "defaultOpen": true

--- a/docs/content/docs/features/sse.mdx
+++ b/docs/content/docs/features/sse.mdx
@@ -145,12 +145,3 @@ const req = http.get(
 );
 ```
 
-### LLM Integration
-
-An LLM agent can observe bundler state via SSE to decide when to proceed:
-
-1. Connect to `GET /sse/events`
-2. Make code changes
-3. Wait for `watch_change` → `bundle_build_started` → `bundle_build_done` or `bundle_build_failed`
-4. If failed, read the error and fix the code
-5. If needed, trigger `POST /reset-cache` to clear stale cache

--- a/example/.mcp.json
+++ b/example/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "rollipop": {
+      "type": "http",
+      "url": "http://localhost:8081/mcp"
+    }
+  }
+}

--- a/packages/rollipop/package.json
+++ b/packages/rollipop/package.json
@@ -72,6 +72,7 @@
     "@commander-js/extra-typings": "^14.0.0",
     "@fastify/middie": "^9.3.1",
     "@inquirer/prompts": "^8.3.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@node-rs/xxhash": "^1.7.6",
     "@react-native-community/cli-server-api": "^20.1.2",
     "@react-native-community/cli-types": "^20.1.2",
@@ -107,7 +108,8 @@
     "strip-ansi": "^7.2.0",
     "url": "^0.11.4",
     "wrap-ansi": "^10.0.0",
-    "ws": "^8.19.0"
+    "ws": "^8.19.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/babel__code-frame": "^7",

--- a/packages/rollipop/src/server/create-dev-server.ts
+++ b/packages/rollipop/src/server/create-dev-server.ts
@@ -19,6 +19,7 @@ import { errorHandler } from './error';
 import { DevServerLogger, logger } from './logger';
 import { control } from './middlewares/control';
 import { requestLogger } from './middlewares/request-logger';
+import { mcp } from './mcp/server';
 import { serveAssets } from './middlewares/serve-assets';
 import { serveBundle } from './middlewares/serve-bundle';
 import { sse } from './middlewares/sse';
@@ -138,6 +139,7 @@ export async function createDevServer(
     .use(devMiddleware)
     .register(sse, { eventBus: sseEventBus })
     .register(control, { projectRoot, eventBus: sseEventBus })
+    .register(mcp, { projectRoot, eventBus: sseEventBus })
     .register(symbolicate, { getBundler })
     .register(serveBundle, { getBundler })
     .register(serveAssets, {

--- a/packages/rollipop/src/server/mcp/server.ts
+++ b/packages/rollipop/src/server/mcp/server.ts
@@ -1,0 +1,155 @@
+import { randomUUID } from 'node:crypto';
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import fp from 'fastify-plugin';
+import { z } from 'zod';
+
+import { FileSystemCache } from '../../core/cache/file-system-cache';
+import type { SSEEventBus } from '../sse/event-bus';
+import type { SSEEvent } from '../sse/types';
+
+export interface McpPluginOptions {
+  projectRoot: string;
+  eventBus: SSEEventBus;
+}
+
+interface SessionEntry {
+  transport: StreamableHTTPServerTransport;
+  server: McpServer;
+}
+
+function createMcpServer(options: McpPluginOptions): McpServer {
+  const { projectRoot, eventBus } = options;
+  const server = new McpServer(
+    { name: 'rollipop', version: '0.1.0' },
+    { capabilities: { logging: {} } },
+  );
+
+  server.registerTool(
+    'reset_cache',
+    {
+      title: 'Reset Cache',
+      description:
+        'Clear the entire build cache. The bundler will rebuild from scratch on next change.',
+    },
+    async () => {
+      FileSystemCache.clearAll(projectRoot);
+      eventBus.emit({ type: 'cache_reset' });
+      return { content: [{ type: 'text' as const, text: 'Cache cleared successfully.' }] };
+    },
+  );
+
+  server.registerTool(
+    'get_build_events',
+    {
+      title: 'Get Build Events',
+      description:
+        'Subscribe to bundler events for a duration. Returns all events (build start/done/fail, watch changes, client logs, device connections) collected during the wait period.',
+      inputSchema: {
+        duration: z
+          .number()
+          .min(1000)
+          .max(60000)
+          .default(10000)
+          .describe('How long to listen for events in milliseconds (1000-60000, default 10000)'),
+      },
+    },
+    async ({ duration }) => {
+      const events: SSEEvent[] = [];
+      const unsubscribe = eventBus.collect(events);
+
+      await new Promise((resolve) => setTimeout(resolve, duration));
+      unsubscribe();
+
+      if (events.length === 0) {
+        return {
+          content: [
+            { type: 'text' as const, text: 'No events received during the listening period.' },
+          ],
+        };
+      }
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(events, null, 2) }],
+      };
+    },
+  );
+
+  return server;
+}
+
+const sessions = new Map<string, SessionEntry>();
+
+const plugin = fp<McpPluginOptions>(
+  (fastify, options) => {
+    fastify.addContentTypeParser(
+      'application/json',
+      { parseAs: 'string' },
+      (_req, body, done) => {
+        try {
+          done(null, JSON.parse(body as string));
+        } catch (error) {
+          done(error as Error, undefined);
+        }
+      },
+    );
+
+    fastify.post('/mcp', async (request, reply) => {
+      const sessionId = request.headers['mcp-session-id'] as string | undefined;
+
+      if (sessionId && sessions.has(sessionId)) {
+        const { transport } = sessions.get(sessionId)!;
+        await transport.handleRequest(request.raw, reply.raw, request.body);
+        return reply;
+      }
+
+      if (!sessionId && isInitializeRequest(request.body)) {
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (sid) => {
+            sessions.set(sid, { transport, server });
+          },
+        });
+
+        transport.onclose = () => {
+          const sid = transport.sessionId;
+          if (sid) sessions.delete(sid);
+        };
+
+        const server = createMcpServer(options);
+        await server.connect(transport);
+        await transport.handleRequest(request.raw, reply.raw, request.body);
+        return reply;
+      }
+
+      return reply.status(400).send({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: 'Bad Request: invalid or missing session' },
+        id: null,
+      });
+    });
+
+    fastify.get('/mcp', async (request, reply) => {
+      const sessionId = request.headers['mcp-session-id'] as string | undefined;
+      if (!sessionId || !sessions.has(sessionId)) {
+        return reply.status(400).send('Missing or invalid session ID');
+      }
+      await sessions.get(sessionId)!.transport.handleRequest(request.raw, reply.raw);
+      return reply;
+    });
+
+    fastify.delete('/mcp', async (request, reply) => {
+      const sessionId = request.headers['mcp-session-id'] as string | undefined;
+      if (!sessionId || !sessions.has(sessionId)) {
+        return reply.status(404).send('Session not found');
+      }
+      await sessions.get(sessionId)!.transport.handleRequest(request.raw, reply.raw);
+      return reply;
+    });
+  },
+  { name: 'mcp' },
+);
+
+export { plugin as mcp };

--- a/packages/rollipop/src/server/middlewares/sse.ts
+++ b/packages/rollipop/src/server/middlewares/sse.ts
@@ -23,8 +23,8 @@ const plugin = fp<SSEPluginOptions>(
       // Send initial comment to flush headers and confirm connection
       res.write(':ok\n\n');
 
-      eventBus.subscribe(res);
-      request.raw.on('close', () => eventBus.unsubscribe(res));
+      eventBus.addClient(res);
+      request.raw.on('close', () => eventBus.removeClient(res));
     });
   },
   { name: 'sse' },

--- a/packages/rollipop/src/server/sse/__tests__/event-bus.spec.ts
+++ b/packages/rollipop/src/server/sse/__tests__/event-bus.spec.ts
@@ -25,14 +25,14 @@ describe('SSEEventBus', () => {
     bus = new SSEEventBus();
   });
 
-  describe('subscribe / unsubscribe', () => {
+  describe('addClient / removeClient', () => {
     it('should track client count', () => {
       const res = createMockResponse();
 
       expect(bus.clientCount).toBe(0);
-      bus.subscribe(res);
+      bus.addClient(res);
       expect(bus.clientCount).toBe(1);
-      bus.unsubscribe(res);
+      bus.removeClient(res);
       expect(bus.clientCount).toBe(0);
     });
   });
@@ -41,8 +41,8 @@ describe('SSEEventBus', () => {
     it('should send SSE-formatted message to all subscribed clients', () => {
       const res1 = createMockResponse();
       const res2 = createMockResponse();
-      bus.subscribe(res1);
-      bus.subscribe(res2);
+      bus.addClient(res1);
+      bus.addClient(res2);
 
       const event: SSEEvent = { type: 'server_ready', host: 'localhost', port: 8081 };
       bus.emit(event);
@@ -52,10 +52,10 @@ describe('SSEEventBus', () => {
       expect(res2.write).toHaveBeenCalledWith(expected);
     });
 
-    it('should not send to unsubscribed clients', () => {
+    it('should not send to removed clients', () => {
       const res = createMockResponse();
-      bus.subscribe(res);
-      bus.unsubscribe(res);
+      bus.addClient(res);
+      bus.removeClient(res);
 
       bus.emit({ type: 'bundle_build_started', id: 'ios-true' });
 
@@ -64,7 +64,7 @@ describe('SSEEventBus', () => {
 
     it('should skip closed connections', () => {
       const res = createMockResponse();
-      bus.subscribe(res);
+      bus.addClient(res);
       (res as unknown as { closed: boolean }).closed = true;
 
       bus.emit({ type: 'bundle_build_started', id: 'ios-true' });
@@ -74,7 +74,7 @@ describe('SSEEventBus', () => {
 
     it('should format different event types correctly', () => {
       const res = createMockResponse();
-      bus.subscribe(res);
+      bus.addClient(res);
 
       bus.emit({ type: 'bundle_build_done', id: 'ios-true', totalModules: 42, duration: 1500 });
       bus.emit({ type: 'watch_change', id: 'ios-true', file: 'src/App.tsx' });
@@ -84,6 +84,29 @@ describe('SSEEventBus', () => {
       expect(res.chunks[0]).toContain('"totalModules":42');
       expect(res.chunks[1]).toContain('event: watch_change');
       expect(res.chunks[1]).toContain('"file":"src/App.tsx"');
+    });
+
+    it('should notify listeners registered via collect', () => {
+      const events: SSEEvent[] = [];
+      bus.collect(events);
+
+      bus.emit({ type: 'bundle_build_started', id: 'ios-true' });
+      bus.emit({ type: 'bundle_build_done', id: 'ios-true', totalModules: 10, duration: 100 });
+
+      expect(events).toHaveLength(2);
+      expect(events[0].type).toBe('bundle_build_started');
+      expect(events[1].type).toBe('bundle_build_done');
+    });
+
+    it('should stop collecting after unsubscribe', () => {
+      const events: SSEEvent[] = [];
+      const unsubscribe = bus.collect(events);
+
+      bus.emit({ type: 'bundle_build_started', id: 'ios-true' });
+      unsubscribe();
+      bus.emit({ type: 'bundle_build_done', id: 'ios-true', totalModules: 10, duration: 100 });
+
+      expect(events).toHaveLength(1);
     });
   });
 });

--- a/packages/rollipop/src/server/sse/event-bus.ts
+++ b/packages/rollipop/src/server/sse/event-bus.ts
@@ -2,8 +2,11 @@ import type { ServerResponse } from 'node:http';
 
 import type { SSEEvent } from './types';
 
+type EventListener = (event: SSEEvent) => void;
+
 export class SSEEventBus {
   private clients: Set<ServerResponse> = new Set();
+  private listeners: Set<EventListener> = new Set();
 
   emit(event: SSEEvent): void {
     const data = JSON.stringify(event);
@@ -13,14 +16,33 @@ export class SSEEventBus {
         client.write(message);
       }
     }
+    for (const listener of this.listeners) {
+      listener(event);
+    }
   }
 
-  subscribe(res: ServerResponse): void {
+  /**
+   * Subscribe an SSE HTTP response client.
+   */
+  addClient(res: ServerResponse): void {
     this.clients.add(res);
   }
 
-  unsubscribe(res: ServerResponse): void {
+  /**
+   * Unsubscribe an SSE HTTP response client.
+   */
+  removeClient(res: ServerResponse): void {
     this.clients.delete(res);
+  }
+
+  /**
+   * Subscribe a listener that collects events into the given array.
+   * Returns an unsubscribe function.
+   */
+  collect(collector: SSEEvent[]): () => void {
+    const listener: EventListener = (event) => collector.push(event);
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
   }
 
   get clientCount(): number {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2404,6 +2404,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hono/node-server@npm:^1.19.9":
+  version: 1.19.12
+  resolution: "@hono/node-server@npm:1.19.12"
+  peerDependencies:
+    hono: ^4
+  checksum: 10c0/06b5c7ba775d585abebe1ece155f3b00cc9013319818c58bba6f1b1e71df44d1d0d6c6e66cd50350ab6f0b9219a182f83c9fe3074b81a1d1ebb0a1493a73db9e
+  languageName: node
+  linkType: hard
+
 "@iconify/types@npm:^2.0.0":
   version: 2.0.0
   resolution: "@iconify/types@npm:2.0.0"
@@ -3315,6 +3324,39 @@ __metadata:
   dependencies:
     langium: "npm:^4.0.0"
   checksum: 10c0/34231cb63412ddbb3c8c6dba6366b958f98b66293b2e5748d3bd6c286acde47862a6ac86b2f6a33e7b5dee6a1895035af06ee48863c787bc20415b89fe77d705
+  languageName: node
+  linkType: hard
+
+"@modelcontextprotocol/sdk@npm:^1.29.0":
+  version: 1.29.0
+  resolution: "@modelcontextprotocol/sdk@npm:1.29.0"
+  dependencies:
+    "@hono/node-server": "npm:^1.19.9"
+    ajv: "npm:^8.17.1"
+    ajv-formats: "npm:^3.0.1"
+    content-type: "npm:^1.0.5"
+    cors: "npm:^2.8.5"
+    cross-spawn: "npm:^7.0.5"
+    eventsource: "npm:^3.0.2"
+    eventsource-parser: "npm:^3.0.0"
+    express: "npm:^5.2.1"
+    express-rate-limit: "npm:^8.2.1"
+    hono: "npm:^4.11.4"
+    jose: "npm:^6.1.3"
+    json-schema-typed: "npm:^8.0.2"
+    pkce-challenge: "npm:^5.0.0"
+    raw-body: "npm:^3.0.0"
+    zod: "npm:^3.25 || ^4.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@cfworker/json-schema": ^4.1.1
+    zod: ^3.25 || ^4.0
+  peerDependenciesMeta:
+    "@cfworker/json-schema":
+      optional: true
+    zod:
+      optional: false
+  checksum: 10c0/7c4bc339205b1652330cd4e6b121cc859079655f2b9c0506bbb15563ba0d07924bda3d949705530532db7f4d2cb86d633dc8f92bc32803d97c7bece2ac63e29f
   languageName: node
   linkType: hard
 
@@ -7323,7 +7365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:8.18.0, ajv@npm:^8.18.0":
+"ajv@npm:8.18.0, ajv@npm:^8.17.1, ajv@npm:^8.18.0":
   version: 8.18.0
   resolution: "ajv@npm:8.18.0"
   dependencies:
@@ -8594,6 +8636,16 @@ __metadata:
   dependencies:
     browserslist: "npm:^4.28.0"
   checksum: 10c0/71da415899633120db7638dd7b250eee56031f63c4560dcba8eeeafd1168fae171d59b223e3fd2e0aa543a490d64bac7d946764721e2c05897056fdfb22cce33
+  languageName: node
+  linkType: hard
+
+"cors@npm:^2.8.5":
+  version: 2.8.6
+  resolution: "cors@npm:2.8.6"
+  dependencies:
+    object-assign: "npm:^4"
+    vary: "npm:^1"
+  checksum: 10c0/ab2bc57b8af8ef8476682a59647f7c55c1a7d406b559ac06119aa1c5f70b96d35036864d197b24cf86e228e4547231088f1f94ca05061dbb14d89cc0bc9d4cab
   languageName: node
   linkType: hard
 
@@ -9954,6 +10006,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventsource-parser@npm:^3.0.0, eventsource-parser@npm:^3.0.1":
+  version: 3.0.6
+  resolution: "eventsource-parser@npm:3.0.6"
+  checksum: 10c0/70b8ccec7dac767ef2eca43f355e0979e70415701691382a042a2df8d6a68da6c2fca35363669821f3da876d29c02abe9b232964637c1b6635c940df05ada78a
+  languageName: node
+  linkType: hard
+
+"eventsource@npm:^3.0.2":
+  version: 3.0.7
+  resolution: "eventsource@npm:3.0.7"
+  dependencies:
+    eventsource-parser: "npm:^3.0.1"
+  checksum: 10c0/c48a73c38f300e33e9f11375d4ee969f25cbb0519608a12378a38068055ae8b55b6e0e8a49c3f91c784068434efe1d9f01eb49b6315b04b0da9157879ce2f67d
+  languageName: node
+  linkType: hard
+
 "example@workspace:example":
   version: 0.0.0-use.local
   resolution: "example@workspace:example"
@@ -10042,7 +10110,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^5.1.0":
+"express-rate-limit@npm:^8.2.1":
+  version: 8.3.2
+  resolution: "express-rate-limit@npm:8.3.2"
+  dependencies:
+    ip-address: "npm:10.1.0"
+  peerDependencies:
+    express: ">= 4.11"
+  checksum: 10c0/5b64d0691071086cdb8cfc6bcd5e761f5687cf4fabdebfe2a043ea5b4d31443637181e7be71e7ffabce76aee816daee62c1ca83250045847957da408a129f650
+  languageName: node
+  linkType: hard
+
+"express@npm:^5.1.0, express@npm:^5.2.1":
   version: 5.2.1
   resolution: "express@npm:5.2.1"
   dependencies:
@@ -11164,6 +11243,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hono@npm:^4.11.4":
+  version: 4.12.10
+  resolution: "hono@npm:4.12.10"
+  checksum: 10c0/3fed7c0c0847968ae51910dd06bc4b64cc336af24ee913efdc105de80b467ddaa9e4f03a2814cb73771622eabbe3e7699998dc0536fe35acb0bac9f5d0e67aa1
+  languageName: node
+  linkType: hard
+
 "html-escaper@npm:^2.0.0":
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
@@ -11400,7 +11486,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.0.1":
+"ip-address@npm:10.1.0, ip-address@npm:^10.0.1":
   version: 10.1.0
   resolution: "ip-address@npm:10.1.0"
   checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
@@ -12178,6 +12264,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:^6.1.3":
+  version: 6.2.2
+  resolution: "jose@npm:6.2.2"
+  checksum: 10c0/201f4776d77eccd339de99fb3ba940fdf03db15e64be7a99b511e53c232e3f3818e3f21b95223d62f99315a2ab76b4251cedd94e067de56893e45273a8d2151b
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -12254,6 +12347,13 @@ __metadata:
   version: 1.0.0
   resolution: "json-schema-traverse@npm:1.0.0"
   checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
+"json-schema-typed@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "json-schema-typed@npm:8.0.2"
+  checksum: 10c0/89f5e2fb1495483b705c027203c07277ee6bf2665165ad25a9cb55de5af7f72570326d13d32565180781e4083ad5c9688102f222baed7b353c2f39c1e02b0428
   languageName: node
   linkType: hard
 
@@ -14240,6 +14340,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-assign@npm:^4":
+  version: 4.1.1
+  resolution: "object-assign@npm:4.1.1"
+  checksum: 10c0/1f4df9945120325d041ccf7b86f31e8bcc14e73d29171e37a7903050e96b81323784ec59f93f102ec635bcf6fa8034ba3ea0a8c7e69fa202b87ae3b6cec5a414
+  languageName: node
+  linkType: hard
+
 "object-inspect@npm:^1.13.3":
   version: 1.13.4
   resolution: "object-inspect@npm:1.13.4"
@@ -14947,6 +15054,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pkce-challenge@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "pkce-challenge@npm:5.0.1"
+  checksum: 10c0/207f4cb976682f27e8324eb49cf71937c98fbb8341a0b8f6142bc6f664825b30e049a54a21b5c034e823ee3c3d412f10d74bd21de78e17452a6a496c2991f57c
+  languageName: node
+  linkType: hard
+
 "pkg-dir@npm:^4.2.0":
   version: 4.2.0
   resolution: "pkg-dir@npm:4.2.0"
@@ -15227,7 +15341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"raw-body@npm:^3.0.1":
+"raw-body@npm:^3.0.0, raw-body@npm:^3.0.1":
   version: 3.0.2
   resolution: "raw-body@npm:3.0.2"
   dependencies:
@@ -16019,6 +16133,7 @@ __metadata:
     "@commander-js/extra-typings": "npm:^14.0.0"
     "@fastify/middie": "npm:^9.3.1"
     "@inquirer/prompts": "npm:^8.3.0"
+    "@modelcontextprotocol/sdk": "npm:^1.29.0"
     "@node-rs/xxhash": "npm:^1.7.6"
     "@react-native-community/cli-server-api": "npm:^20.1.2"
     "@react-native-community/cli-types": "npm:^20.1.2"
@@ -16061,6 +16176,7 @@ __metadata:
     vite-plus: "catalog:"
     wrap-ansi: "npm:^10.0.0"
     ws: "npm:^8.19.0"
+    zod: "npm:^4.3.6"
   bin:
     rollipop: ./bin/index.js
   languageName: unknown
@@ -17553,7 +17669,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vary@npm:^1.1.2, vary@npm:~1.1.2":
+"vary@npm:^1, vary@npm:^1.1.2, vary@npm:~1.1.2":
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: 10c0/f15d588d79f3675135ba783c91a4083dcd290a2a5be9fcb6514220a1634e23df116847b1cc51f66bfb0644cf9353b2abb7815ae499bab06e46dd33c1a6bf1f4f
@@ -18003,7 +18119,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4.3.6":
+"zod-to-json-schema@npm:^3.25.1":
+  version: 3.25.2
+  resolution: "zod-to-json-schema@npm:3.25.2"
+  peerDependencies:
+    zod: ^3.25.28 || ^4
+  checksum: 10c0/dd300554393903022487688af14fbda5c719ba8179702bb55b3aa86318830467f0f7beb7d654036975ac963dc4843b72e59636448bfff9a0608f277bb6a14939
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25 || ^4.0, zod@npm:^4.3.6":
   version: 4.3.6
   resolution: "zod@npm:4.3.6"
   checksum: 10c0/860d25a81ab41d33aa25f8d0d07b091a04acb426e605f396227a796e9e800c44723ed96d0f53a512b57be3d1520f45bf69c0cb3b378a232a00787a2609625307


### PR DESCRIPTION
## Summary
- Embed MCP (Model Context Protocol) server at `/mcp` endpoint using Streamable HTTP transport
- Two MCP tools: `reset_cache` (clear build cache) and `get_build_events` (collect bundler events for a duration)
- Per-session `McpServer` instances with proper session lifecycle management
- `SSEEventBus.collect()` added for array-based event collection (used by MCP tools)
- Documentation updated with MCP setup and usage guide

<img width="993" height="914" alt="Screenshot 2026-04-06 at 08 29 35" src="https://github.com/user-attachments/assets/0c07f08c-02f8-4265-921f-36da287f29db" />


## Usage
```json
// .mcp.json
{
  "mcpServers": {
    "rollipop": {
      "type": "http",
      "url": "http://localhost:8081/mcp"
    }
  }
}
```

## Test plan
- [x] All 189 tests pass
- [x] Lint passes with 0 warnings
- [x] Typecheck passes