### PR TITLE
test(server): add Node runtime e2e harness (lifecycle + HMR)

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -73,3 +73,6 @@ yarn-error.log
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# e2e runtime test fixtures (cloned per test run by packages/rollipop/e2e/runtime)
+rollipop-e2e-*

--- a/example/sse-client.mts
+++ b/example/sse-client.mts
@@ -32,13 +32,9 @@ const EVENT_STYLES: Record<SSEEvent['type'], { label: string; color: (s: string)
   bundle_build_failed: { label: 'build:fail', color: pc.red },
   watch_change: { label: 'watch', color: pc.yellow },
   client_log: { label: 'log', color: pc.cyan },
-  hmr_update: { label: 'hmr:update', color: pc.magenta },
-  hmr_reload: { label: 'hmr:reload', color: pc.magenta },
   device_connected: { label: 'device:on', color: pc.green },
   device_disconnected: { label: 'device:off', color: pc.red },
   cache_reset: { label: 'cache:reset', color: pc.yellow },
-  symbolicate_request: { label: 'sym:req', color: pc.cyan },
-  symbolicate_result: { label: 'sym:res', color: pc.cyan },
 };
 
 function timestamp(): string {

--- a/packages/rollipop/e2e/runtime/__fixtures__/hmr-app/App.tsx
+++ b/packages/rollipop/e2e/runtime/__fixtures__/hmr-app/App.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+
+// e2e-marker: initial
+export function App() {
+  return (
+    <View>
+      <Text>hmr-e2e-initial</Text>
+    </View>
+  );
+}
+
+// Explicit HMR boundary so rolldown can emit a Patch (hmr:update) for
+// edits to this file. Without this, changes would bubble up to a
+// FullReload because the built-in react-refresh-wrapper plugin only
+// wraps class components (has_refresh && extends Component).
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/packages/rollipop/e2e/runtime/__fixtures__/hmr-app/app.json
+++ b/packages/rollipop/e2e/runtime/__fixtures__/hmr-app/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "RollipopRuntimeE2E",
+  "displayName": "RollipopRuntimeE2E"
+}

--- a/packages/rollipop/e2e/runtime/__fixtures__/hmr-app/index.js
+++ b/packages/rollipop/e2e/runtime/__fixtures__/hmr-app/index.js
@@ -1,0 +1,6 @@
+import { AppRegistry } from 'react-native';
+
+import { App } from './App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/packages/rollipop/e2e/runtime/__fixtures__/hmr-app/rollipop.config.ts
+++ b/packages/rollipop/e2e/runtime/__fixtures__/hmr-app/rollipop.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'rollipop';
+
+export default defineConfig({
+  entry: 'index.js',
+});

--- a/packages/rollipop/e2e/runtime/harness.ts
+++ b/packages/rollipop/e2e/runtime/harness.ts
@@ -1,0 +1,391 @@
+import fs from 'node:fs';
+import http from 'node:http';
+import net from 'node:net';
+import path from 'node:path';
+
+import WebSocket from 'ws';
+
+import { loadConfig } from '../../src/config';
+import type { ResolvedConfig } from '../../src/config/defaults';
+import type { SSEEvent } from '../../src/server/sse/types';
+import type { DevServer } from '../../src/server/types';
+import type { HMRClientLogLevel, HMRClientMessage, HMRServerMessage } from '../../src/types/hmr';
+import { runServer } from '../../src/utils/run-server';
+
+const FIXTURES_DIR = path.resolve(import.meta.dirname, '__fixtures__');
+const EXAMPLE_DIR = path.resolve(import.meta.dirname, '../../../../example');
+
+/**
+ * Copy a fixture into a unique directory under `example/` so the resulting
+ * project can resolve `react-native` (and related deps) from the example
+ * workspace's node_modules. Each call returns a fresh path → guarantees a
+ * distinct BundlerPool cache key across tests.
+ */
+export function cloneFixture(name: string): { dir: string; cleanup: () => void } {
+  const src = path.join(FIXTURES_DIR, name);
+  const dirName = `rollipop-e2e-${process.pid}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  const dir = path.join(EXAMPLE_DIR, dirName);
+
+  fs.cpSync(src, dir, { recursive: true });
+
+  const cleanup = () => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  };
+
+  return { dir, cleanup };
+}
+
+/**
+ * Reserve a random free port by binding to :0 and immediately closing.
+ * Race-free enough for test concurrency within a single process.
+ */
+export function pickPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (typeof address === 'object' && address) {
+        const { port } = address;
+        server.close(() => resolve(port));
+      } else {
+        server.close();
+        reject(new Error('Failed to pick a port'));
+      }
+    });
+  });
+}
+
+export interface TestServer {
+  server: DevServer;
+  config: ResolvedConfig;
+  root: string;
+  host: string;
+  port: number;
+  baseUrl: string;
+  entryAbs: string;
+  close: () => Promise<void>;
+}
+
+export async function startTestServer(fixtureDir: string): Promise<TestServer> {
+  const host = '127.0.0.1';
+  const port = await pickPort();
+
+  const config = await loadConfig({ cwd: fixtureDir, mode: 'development' });
+
+  // Mirror the workaround used by server.spec.ts: the prelude plugin reads
+  // entry via fs.readFileSync, which requires an absolute path.
+  const entryAbs = path.resolve(config.root, config.entry);
+  (config as any).entry = entryAbs;
+
+  // Silence terminal reporter in tests.
+  (config as any).terminal = { status: 'none' };
+
+  const server = await runServer(config, {
+    host,
+    port,
+    buildOptions: { cache: false },
+  });
+
+  const close = async () => {
+    try {
+      await server.instance.close();
+    } catch {
+      // ignore double-close
+    }
+  };
+
+  return {
+    server,
+    config,
+    root: fixtureDir,
+    host,
+    port,
+    baseUrl: `http://${host}:${port}`,
+    entryAbs,
+    close,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* SSE subscriber                                                             */
+/* -------------------------------------------------------------------------- */
+
+export interface SSESubscription {
+  events: SSEEvent[];
+  /** Resolves when a matching event arrives, or rejects on timeout. */
+  waitFor<T extends SSEEvent['type']>(
+    type: T,
+    predicate?: (event: Extract<SSEEvent, { type: T }>) => boolean,
+    timeoutMs?: number,
+  ): Promise<Extract<SSEEvent, { type: T }>>;
+  close: () => void;
+}
+
+/**
+ * Subscribe to the dev server's `/sse/events` endpoint using `http.get`. We
+ * use the raw http module (rather than global fetch) because its streaming
+ * semantics for `text/event-stream` are predictable across Node versions —
+ * `res` is a Readable that emits `data` events immediately as the server
+ * flushes writes.
+ */
+export async function subscribeSSE(baseUrl: string): Promise<SSESubscription> {
+  const url = new URL(`${baseUrl}/sse/events`);
+
+  const events: SSEEvent[] = [];
+  const listeners = new Set<(event: SSEEvent) => void>();
+  let buffer = '';
+  let closed = false;
+
+  const processChunk = () => {
+    let idx: number;
+    while ((idx = buffer.indexOf('\n\n')) !== -1) {
+      const raw = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 2);
+
+      const dataLine = raw.split('\n').find((line) => line.startsWith('data:'));
+      if (!dataLine) continue;
+
+      try {
+        const parsed = JSON.parse(dataLine.slice(5).trim()) as SSEEvent;
+        events.push(parsed);
+        for (const l of listeners) l(parsed);
+      } catch {
+        // ignore non-JSON comments / heartbeats
+      }
+    }
+  };
+
+  const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
+    const req = http.get(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname + url.search,
+        headers: { accept: 'text/event-stream' },
+      },
+      (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Failed to open SSE stream: ${res.statusCode}`));
+          res.resume();
+          return;
+        }
+        res.setEncoding('utf8');
+        res.on('data', (chunk: string) => {
+          buffer += chunk;
+          processChunk();
+        });
+        res.on('error', () => {
+          closed = true;
+        });
+        res.on('close', () => {
+          closed = true;
+        });
+        resolve(res);
+      },
+    );
+    req.on('error', reject);
+  });
+
+  const waitFor: SSESubscription['waitFor'] = (type, predicate, timeoutMs = 30_000) => {
+    // Check already-received events first.
+    const existing = events.find(
+      (e) => e.type === type && (predicate ? predicate(e as any) : true),
+    );
+    if (existing) return Promise.resolve(existing as any);
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        listeners.delete(onEvent);
+        reject(
+          new Error(
+            `Timed out after ${timeoutMs}ms waiting for SSE event "${type}". ` +
+              `Received: ${events.map((e) => e.type).join(', ') || '(none)'}`,
+          ),
+        );
+      }, timeoutMs);
+
+      const onEvent = (event: SSEEvent) => {
+        if (event.type !== type) return;
+        if (predicate && !predicate(event as any)) return;
+        clearTimeout(timer);
+        listeners.delete(onEvent);
+        resolve(event as any);
+      };
+
+      listeners.add(onEvent);
+    });
+  };
+
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    response.destroy();
+  };
+
+  return { events, waitFor, close };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fake HMR WebSocket client                                                  */
+/* -------------------------------------------------------------------------- */
+
+export interface FakeClientOptions {
+  baseUrl: string;
+  platform: 'ios' | 'android';
+  /**
+   * Matches the `bundleEntry` field sent in `hmr:connected`. The server maps
+   * this (via getBaseBundleName) onto the BundlerPool cache key, so it must
+   * agree with whatever path the `/:name.bundle` HTTP route uses. Default
+   * `"index.bundle"` shares the pool instance with `/index.bundle` requests.
+   */
+  bundleEntry?: string;
+}
+
+export interface FakeClient {
+  ws: WebSocket;
+  messages: HMRServerMessage[];
+  sendLog: (level: HMRClientLogLevel, ...data: unknown[]) => void;
+  sendRaw: (message: HMRClientMessage) => void;
+  invalidate: (moduleId: string) => void;
+  /**
+   * Register module IDs (absolute file paths) with the server so rolldown's
+   * dev engine knows which modules this fake client has "loaded". Without
+   * this, incremental updates collapse to `Noop` and the dev engine never
+   * dispatches a concrete Patch or FullReload to the socket.
+   */
+  registerModules: (modules: string[]) => void;
+  waitForMessage<T extends HMRServerMessage['type']>(
+    type: T,
+    predicate?: (message: Extract<HMRServerMessage, { type: T }>) => boolean,
+    timeoutMs?: number,
+  ): Promise<Extract<HMRServerMessage, { type: T }>>;
+  close: () => Promise<void>;
+}
+
+export async function createFakeClient({
+  baseUrl,
+  platform,
+  bundleEntry = 'index.bundle',
+}: FakeClientOptions): Promise<FakeClient> {
+  const wsUrl = baseUrl.replace(/^http/, 'ws') + '/hot';
+  const ws = new WebSocket(wsUrl);
+
+  const messages: HMRServerMessage[] = [];
+  const listeners = new Set<(message: HMRServerMessage) => void>();
+
+  ws.on('message', (raw: Buffer | ArrayBuffer | Buffer[]) => {
+    try {
+      let buf: Buffer;
+      if (Array.isArray(raw)) {
+        buf = Buffer.concat(raw);
+      } else if (raw instanceof Buffer) {
+        buf = raw;
+      } else {
+        buf = Buffer.from(new Uint8Array(raw));
+      }
+      const parsed = JSON.parse(buf.toString('utf-8')) as HMRServerMessage;
+      messages.push(parsed);
+      for (const l of listeners) l(parsed);
+    } catch {
+      // ignore non-JSON
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onOpen = () => {
+      ws.off('error', onError);
+      resolve();
+    };
+    const onError = (err: Error) => {
+      ws.off('open', onOpen);
+      reject(err);
+    };
+    ws.once('open', onOpen);
+    ws.once('error', onError);
+  });
+
+  const sendRaw = (message: HMRClientMessage) => {
+    ws.send(JSON.stringify(message));
+  };
+
+  // Handshake
+  sendRaw({ type: 'hmr:connected', platform, bundleEntry });
+
+  const sendLog: FakeClient['sendLog'] = (level, ...data) => {
+    sendRaw({ type: 'hmr:log', level, data });
+  };
+
+  const invalidate: FakeClient['invalidate'] = (moduleId) => {
+    sendRaw({ type: 'hmr:invalidate', moduleId });
+  };
+
+  const registerModules: FakeClient['registerModules'] = (modules) => {
+    sendRaw({ type: 'hmr:module-registered', modules });
+  };
+
+  const waitForMessage: FakeClient['waitForMessage'] = (type, predicate, timeoutMs = 30_000) => {
+    const existing = messages.find(
+      (m) => m.type === type && (predicate ? predicate(m as any) : true),
+    );
+    if (existing) return Promise.resolve(existing as any);
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        listeners.delete(onMessage);
+        reject(
+          new Error(
+            `Timed out after ${timeoutMs}ms waiting for HMR message "${type}". ` +
+              `Received: ${messages.map((m) => m.type).join(', ') || '(none)'}`,
+          ),
+        );
+      }, timeoutMs);
+
+      const onMessage = (message: HMRServerMessage) => {
+        if (message.type !== type) return;
+        if (predicate && !predicate(message as any)) return;
+        clearTimeout(timer);
+        listeners.delete(onMessage);
+        resolve(message as any);
+      };
+
+      listeners.add(onMessage);
+    });
+  };
+
+  const close = async () => {
+    if (ws.readyState === WebSocket.CLOSED) return;
+    await new Promise<void>((resolve) => {
+      ws.once('close', () => resolve());
+      ws.close();
+    });
+  };
+
+  return {
+    ws,
+    messages,
+    sendLog,
+    sendRaw,
+    invalidate,
+    registerModules,
+    waitForMessage,
+    close,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* FS mutation helper                                                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Overwrite a file in the fixture. The rolldown watcher picks it up and
+ * triggers the HMR update pipeline.
+ */
+export function writeFixtureFile(fixtureDir: string, relPath: string, content: string): void {
+  fs.writeFileSync(path.join(fixtureDir, relPath), content);
+}
+
+export function readFixtureFile(fixtureDir: string, relPath: string): string {
+  return fs.readFileSync(path.join(fixtureDir, relPath), 'utf-8');
+}

--- a/packages/rollipop/e2e/runtime/hmr.spec.ts
+++ b/packages/rollipop/e2e/runtime/hmr.spec.ts
@@ -1,0 +1,213 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vite-plus/test';
+
+import {
+  type FakeClient,
+  type SSESubscription,
+  type TestServer,
+  cloneFixture,
+  createFakeClient,
+  startTestServer,
+  subscribeSSE,
+  writeFixtureFile,
+} from './harness';
+
+const APP_TSX_ORIGINAL = `import React from 'react';
+import { Text, View } from 'react-native';
+
+// e2e-marker: initial
+export function App() {
+  return (
+    <View>
+      <Text>hmr-e2e-initial</Text>
+    </View>
+  );
+}
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}
+`;
+
+// Module IDs the rolldown dev engine uses internally are paths relative to
+// the project root, not absolute paths — see the register calls emitted in
+// the dev bundle (e.g. `__rolldown_runtime__.registerModule("App.tsx", ...)`).
+// If we register absolute paths here the dev engine fails to match and
+// returns `Patch` with empty `applyUpdates([])`, so no concrete update or
+// reload message is dispatched.
+const APP_MODULE_ID = 'App.tsx';
+const INDEX_MODULE_ID = 'index.js';
+
+let fixture: { dir: string; cleanup: () => void };
+let ts: TestServer;
+let sse: SSESubscription;
+let client: FakeClient;
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+beforeAll(async () => {
+  fixture = cloneFixture('hmr-app');
+  ts = await startTestServer(fixture.dir);
+
+  sse = await subscribeSSE(ts.baseUrl);
+
+  // Activate the watcher via an HTTP bundle request — the HTTP build and
+  // the HMR WS share a bundler instance (see utils/id.ts#createId).
+  const bundleRes = await fetch(`${ts.baseUrl}/index.bundle?platform=ios&dev=true`);
+  if (bundleRes.status !== 200) {
+    throw new Error(`Initial /index.bundle failed: HTTP ${bundleRes.status}`);
+  }
+  await bundleRes.text();
+  await sse.waitFor('bundle_build_done', undefined, 180_000);
+
+  client = await createFakeClient({ baseUrl: ts.baseUrl, platform: 'ios' });
+
+  // Register modules with their rolldown-internal IDs so the dev engine
+  // recognises them when files change.
+  client.registerModules([INDEX_MODULE_ID, APP_MODULE_ID]);
+
+  // registerModules is fire-and-forget over WS; give the server a moment to
+  // call devEngine.registerModules before the first file-change test runs.
+  await sleep(1000);
+}, 300_000);
+
+afterAll(async () => {
+  await client?.close();
+  sse?.close();
+  await ts?.close();
+  fixture?.cleanup();
+}, 60_000);
+
+afterEach(async () => {
+  writeFixtureFile(fixture.dir, 'App.tsx', APP_TSX_ORIGINAL);
+  await sleep(200);
+});
+
+describe('runtime e2e: HMR', () => {
+  it('dispatches a FullReload (hmr:reload) when an entry module without an accept boundary is invalidated', async () => {
+    // NOTE: The rolldown dev-engine watcher in its current state only emits
+    // watchChange / onHmrUpdates for files that are themselves HMR accept
+    // boundaries — writes to the entry (`index.js`) or non-boundary deps
+    // (e.g. `app.json`) never reach the pipeline. Verified empirically with
+    // an e2e probe (see the project log).
+    //
+    // We therefore drive the FullReload path via `hmr:invalidate`, which is
+    // the same runtime signal a real client would send when it can't handle
+    // an incoming update. rolldown's HMR engine walks importers looking for
+    // an accept boundary (hmr_stage.rs#propagate_update) and, finding none
+    // above the entry, returns `HmrUpdate::FullReload` — the exact behaviour
+    // the user expects for entry-file changes.
+    const msgCursor = client.messages.length;
+
+    const reloadPromise = client.waitForMessage(
+      'hmr:reload',
+      (m) => client.messages.indexOf(m) >= msgCursor,
+      60_000,
+    );
+    const updateDonePromise = client.waitForMessage(
+      'hmr:update-done',
+      (m) => client.messages.indexOf(m) >= msgCursor,
+      60_000,
+    );
+
+    client.invalidate(INDEX_MODULE_ID);
+
+    await reloadPromise;
+    await updateDonePromise;
+
+    const newMessages = client.messages.slice(msgCursor).map((m) => m.type);
+    expect(newMessages).toContain('hmr:reload');
+    expect(newMessages).not.toContain('hmr:update');
+  }, 60_000);
+
+  it('dispatches a Patch (hmr:update) when a module with import.meta.hot.accept changes', async () => {
+    const msgCursor = client.messages.length;
+    const eventCursor = sse.events.length;
+
+    const watchPromise = sse.waitFor(
+      'watch_change',
+      (e) => e.file.endsWith('App.tsx') && sse.events.indexOf(e) >= eventCursor,
+      60_000,
+    );
+    const updateStartPromise = client.waitForMessage(
+      'hmr:update-start',
+      (m) => client.messages.indexOf(m) >= msgCursor,
+      60_000,
+    );
+    const updatePromise = client.waitForMessage(
+      'hmr:update',
+      (m) => client.messages.indexOf(m) >= msgCursor,
+      60_000,
+    );
+    const updateDonePromise = client.waitForMessage(
+      'hmr:update-done',
+      (m) => client.messages.indexOf(m) >= msgCursor,
+      60_000,
+    );
+
+    writeFixtureFile(
+      fixture.dir,
+      'App.tsx',
+      APP_TSX_ORIGINAL.replace('hmr-e2e-initial', 'hmr-e2e-patched'),
+    );
+
+    const watch = await watchPromise;
+    expect(watch.file).toContain('App.tsx');
+
+    await updateStartPromise;
+    const update = await updatePromise;
+    await updateDonePromise;
+
+    // The Patch body is the rolldown runtime's `applyUpdates(...)` call.
+    // A healthy Patch for a registered + accepted module contains non-empty
+    // update arguments — not just `applyUpdates([])`, which is what you get
+    // when registration misses.
+    expect(typeof update.code).toBe('string');
+    expect(update.code).toContain('__rolldown_runtime__');
+    expect(update.code).toContain('applyUpdates');
+    expect(update.code).not.toMatch(/applyUpdates\(\s*\[\s*\]\s*\)/);
+
+    const newMessages = client.messages.slice(msgCursor).map((m) => m.type);
+    expect(newMessages).not.toContain('hmr:reload');
+  }, 180_000);
+
+  it('reports a build error via SSE bundle_build_failed and WS hmr:error', async () => {
+    const msgCursor = client.messages.length;
+    const eventCursor = sse.events.length;
+
+    const failedPromise = sse.waitFor(
+      'bundle_build_failed',
+      (e) => sse.events.indexOf(e) >= eventCursor,
+      60_000,
+    );
+    const errorPromise = client.waitForMessage(
+      'hmr:error',
+      (m) => client.messages.indexOf(m) >= msgCursor,
+      60_000,
+    );
+
+    writeFixtureFile(
+      fixture.dir,
+      'App.tsx',
+      `import React from 'react';
+import { Text, View } from 'react-native';
+
+export function App() {
+  return (
+    <View>
+      <Text>broken
+    </View>
+  );
+}
+`,
+    );
+
+    const failed = await failedPromise;
+    expect(typeof failed.error).toBe('string');
+    expect(failed.error.length).toBeGreaterThan(0);
+
+    const error = await errorPromise;
+    expect(error.payload.type).toBeTruthy();
+    expect(error.payload.message).toBeTruthy();
+    expect(error.payload.errors.length).toBeGreaterThan(0);
+  }, 120_000);
+});

--- a/packages/rollipop/e2e/runtime/lifecycle.spec.ts
+++ b/packages/rollipop/e2e/runtime/lifecycle.spec.ts
@@ -1,0 +1,103 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+
+import {
+  type SSESubscription,
+  type TestServer,
+  cloneFixture,
+  createFakeClient,
+  startTestServer,
+  subscribeSSE,
+} from './harness';
+
+let fixture: { dir: string; cleanup: () => void };
+let ts: TestServer;
+
+beforeAll(async () => {
+  fixture = cloneFixture('hmr-app');
+  ts = await startTestServer(fixture.dir);
+}, 60_000);
+
+afterAll(async () => {
+  await ts?.close();
+  fixture?.cleanup();
+}, 60_000);
+
+describe('runtime e2e: lifecycle', () => {
+  it('GET /status returns packager-status:running', async () => {
+    const res = await fetch(`${ts.baseUrl}/status`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('packager-status:running');
+  });
+
+  it('emits bundle_build_started and bundle_build_done when /index.bundle is requested', async () => {
+    const sse: SSESubscription = await subscribeSSE(ts.baseUrl);
+    try {
+      const [startedEvent, doneEvent, res] = await Promise.all([
+        sse.waitFor('bundle_build_started', undefined, 120_000),
+        sse.waitFor('bundle_build_done', undefined, 120_000),
+        fetch(`${ts.baseUrl}/index.bundle?platform=ios&dev=true`),
+      ]);
+
+      expect(res.status).toBe(200);
+      expect(startedEvent.id).toBeTruthy();
+      expect(doneEvent.id).toBe(startedEvent.id);
+      expect(doneEvent.totalModules).toBeGreaterThan(0);
+      expect(doneEvent.duration).toBeGreaterThanOrEqual(0);
+    } finally {
+      sse.close();
+    }
+  }, 180_000);
+
+  it('emits device_connected when an HMR client connects, and device_disconnected on close', async () => {
+    const sse = await subscribeSSE(ts.baseUrl);
+    try {
+      const connectedPromise = sse.waitFor('device_connected', undefined, 10_000);
+      const client = await createFakeClient({
+        baseUrl: ts.baseUrl,
+        platform: 'ios',
+      });
+      const connected = await connectedPromise;
+      expect(typeof connected.clientId).toBe('number');
+
+      const disconnectedPromise = sse.waitFor(
+        'device_disconnected',
+        (e) => e.clientId === connected.clientId,
+        10_000,
+      );
+      await client.close();
+      const disconnected = await disconnectedPromise;
+      expect(disconnected.clientId).toBe(connected.clientId);
+    } finally {
+      sse.close();
+    }
+  }, 30_000);
+
+  it('forwards hmr:log from the client as a client_log SSE event', async () => {
+    const sse = await subscribeSSE(ts.baseUrl);
+    const client = await createFakeClient({
+      baseUrl: ts.baseUrl,
+      platform: 'ios',
+      bundleEntry: ts.entryAbs,
+    });
+    try {
+      // client_log is dispatched to SSE via the reporter chain, which is only
+      // wired up after the bundler instance has initialized. Wait for the
+      // first bundle_build_done on this platform before sending the log.
+      await sse.waitFor('bundle_build_done', undefined, 120_000);
+
+      const marker = `hello-${Date.now()}`;
+      const logPromise = sse.waitFor(
+        'client_log',
+        (e) =>
+          Array.isArray(e.data) && e.data.some((d) => typeof d === 'string' && d.includes(marker)),
+        10_000,
+      );
+      client.sendLog('info', marker, { count: 42 });
+      const event = await logPromise;
+      expect(event.data).toEqual(expect.arrayContaining([expect.stringContaining(marker)]));
+    } finally {
+      await client.close();
+      sse.close();
+    }
+  }, 180_000);
+});

--- a/packages/rollipop/src/server/bundler-pool.ts
+++ b/packages/rollipop/src/server/bundler-pool.ts
@@ -105,7 +105,15 @@ export class BundlerDevEngine extends EventEmitter<BundlerDevEngineEventMap> {
               error: errorOrResult,
             });
             const normalizedError = normalizeRolldownError(errorOrResult);
-            this.emit('buildFailed', normalizedError);
+            // Route through the reporter pipeline so subscribers downstream
+            // (SSE bus, custom reporters) observe `bundle_build_failed` for
+            // HMR-time errors — not just full builds. `bindReporter` also
+            // re-emits the local `buildFailed` event, which HMRServer uses
+            // to dispatch `hmr:error` to the connected client.
+            this.config.reporter?.update({
+              type: 'bundle_build_failed',
+              error: normalizedError,
+            });
           } else {
             logger.trace('Detected changed files', {
               bundlerId: this.id,

--- a/packages/rollipop/src/server/sse/types.ts
+++ b/packages/rollipop/src/server/sse/types.ts
@@ -1,5 +1,3 @@
-import type { StackFrameInput, StackFrameOutput, CodeFrame } from '../symbolicate';
-
 export type SSEEvent =
   // Build lifecycle events (from reporter pipeline, always have bundler id)
   | { type: 'bundle_build_started'; id: string }
@@ -8,12 +6,6 @@ export type SSEEvent =
   | { type: 'watch_change'; id: string; file: string }
   // Client log events (from HMR client)
   | { type: 'client_log'; data: unknown[] }
-  // HMR events
-  | { type: 'hmr_update'; id: string; platform: string; updatedModules: number }
-  | { type: 'hmr_reload'; id: string; platform: string }
-  // Symbolicate events
-  | { type: 'symbolicate_request'; stack: StackFrameInput[] }
-  | { type: 'symbolicate_result'; stack: StackFrameOutput[]; codeFrame: CodeFrame | null }
   // Device lifecycle events
   | { type: 'device_connected'; clientId: number }
   | { type: 'device_disconnected'; clientId: number }

--- a/packages/rollipop/src/server/wss/hmr-server.ts
+++ b/packages/rollipop/src/server/wss/hmr-server.ts
@@ -204,7 +204,17 @@ export class HMRServer extends WebSocketServer {
     }
 
     if (instance != null) {
-      void instance.devEngine.removeClient(String(client.id));
+      try {
+        void instance.devEngine.removeClient(String(client.id));
+      } catch (error) {
+        // `devEngine` throws an invariant error if the client disconnects
+        // before the underlying bundler finishes initializing. Log and
+        // continue so the cleanup path isn't left half-done.
+        this.logger.warn(
+          `Skipped devEngine.removeClient for client ${client.id}: ` +
+            (error instanceof Error ? error.message : String(error)),
+        );
+      }
     }
 
     this.bindings.delete(client.id);

--- a/packages/rollipop/tsconfig.json
+++ b/packages/rollipop/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "exclude": ["**/dist/*", "e2e/__fixtures__"]
+  "exclude": ["**/dist/*", "**/__fixtures__/**"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       'example/andorid/**',
       'example/ios/**',
       'rolldown/**',
-      '**/e2e/__fixtures__/**',
+      '**/__fixtures__/**',
       '**/.**',
     ],
     experimentalSortImports: {
@@ -34,7 +34,7 @@ export default defineConfig({
     },
   },
   lint: {
-    ignorePatterns: ['rolldown/**', 'docs/**', 'example/**', '**/e2e/__fixtures__/**'],
+    ignorePatterns: ['rolldown/**', 'docs/**', 'example/**', '**/__fixtures__/**'],
     options: {
       typeAware: true,
       typeCheck: true,


### PR DESCRIPTION
## Summary

Adds a Node-based e2e suite at `packages/rollipop/e2e/runtime` that drives the dev server through its real public API (HTTP bundle + HMR WebSocket + SSE) without a simulator. Covers the four signals requested: **build trigger, HMR Patch / FullReload, client log reception, build error propagation.**

Folds in three small server fixes that fell out while writing the tests.

### Commits

1. `chore(server): prune unemitted SSE event types` — `hmr_update`, `hmr_reload`, `symbolicate_request`, `symbolicate_result` had type declarations but no emit sites. Removed from the union and from the example SSE viewer's label map.
2. `fix(server): log-only recovery when HMR client disconnects pre-init` — `HMRServer.cleanup` threw `DevEngine is not initialized` when a socket closed before `BundlerDevEngine.initialize` resolved. Now wraps `devEngine.removeClient` in try/catch and logs.
3. `fix(server): route HMR build failures through the reporter pipeline` — `onHmrUpdates` error branch only fired the local `buildFailed` emitter (→ `hmr:error` WS), never `config.reporter` (→ SSE `bundle_build_failed`). Now dispatches via `config.reporter.update(...)` so both paths fan out from a single emit.
4. `test(server): add Node runtime e2e harness (lifecycle + HMR)` — the test suite itself.

### Harness

- `cloneFixture(name)` — copies a fixture into `example/` so RN deps resolve via the example workspace's node_modules; each clone path is unique so BundlerPool cache keys don't collide between tests
- `startTestServer(fixtureDir)` — random free port + real `runServer` call
- `subscribeSSE(baseUrl)` — built on `node:http` instead of `fetch`; fetch's streamed body proved inconsistent across Node versions for `text/event-stream`
- `createFakeClient({baseUrl, platform, bundleEntry?})` — fake HMR WebSocket client with `sendLog`, `invalidate`, `registerModules`, `waitForMessage`

### Specs

- **lifecycle**: `/status` 200 · `/index.bundle` → `bundle_build_started` / `_done` SSE · WS connect/close → `device_connected` / `device_disconnected` SSE · `hmr:log` → `client_log` SSE
- **HMR**: source change with `import.meta.hot.accept()` boundary → `watch_change` SSE + Patch (`hmr:update-start` / `hmr:update` / `hmr:update-done`, non-empty `applyUpdates`) · `hmr:invalidate("index.js")` → FullReload (`hmr:update-start` / `hmr:reload` / `hmr:update-done`) · parse error → both SSE `bundle_build_failed` AND WS `hmr:error`

### Notes for reviewers

- **HTTP bundle precedes HMR.** The rolldown dev engine only starts watching after the first full build. `hmr:connected` alone is not enough — beforeAll hits `/index.bundle` first. Comments in `hmr.spec.ts` + `utils/id.ts#createId` explain why the two requests share a bundler instance.
- **Module IDs are cwd-relative.** `hmr:module-registered` with absolute paths silently produces `Patch` with empty `applyUpdates([])`. Verified by inspecting the dev bundle (`registerModule("App.tsx", ...)`). Harness passes `"App.tsx"` / `"index.js"`.
- **Entry-file file-change → FullReload isn't observable.** An e2e probe showed the rolldown dev watcher only reacts to files that are themselves HMR accept boundaries — writes to `index.js` / `app.json` never reach `watchChange` or `onHmrUpdates`. The FullReload spec therefore drives `hmr:invalidate("index.js")` directly, which is the same runtime signal a real client sends when it can't handle an update (documented in `hmr.spec.ts`).
- **React-Refresh wrapper scope (checked per the original ask).** `rolldown_plugin_rollipop_react_refresh_wrapper` early-returns on non-JSX via `is_jsx()`, and its `add_refresh_wrapper` only injects `import.meta.hot.accept` when both `$RefreshReg$(` is present **and** the class-component regex matches. That means neither entry files nor function-component modules get the accept wrapper injected. The fixture adds an explicit `import.meta.hot.accept()` to `App.tsx` to exercise the Patch path.

### CI

`.github/workflows/ci.yml` runs `yarn test:all` → rollipop's `vp test --run` picks up `*.spec.ts` under `packages/rollipop`, so the new `e2e/runtime/` specs run on every PR with no workflow changes.

## Test plan

- [x] `yarn fmt` clean
- [x] `yarn lint` clean
- [x] `yarn typecheck:all` clean
- [x] `yarn test:all` — 31 files / 195 tests pass locally (12s)
- [ ] CI green on GitHub