### PR TITLE
refactor: expose builtin plugins via rollipop/plugins sub-path

### DIFF
--- a/.changeset/plugins-subpath.md
+++ b/.changeset/plugins-subpath.md
@@ -1,0 +1,15 @@
+---
+"rollipop": patch
+---
+
+Replace `BuiltinPlugins` namespace with the `rollipop/plugins` sub-path. Built-in plugins are now imported by name:
+
+```ts
+// Before
+import { BuiltinPlugins } from 'rollipop';
+plugins: [BuiltinPlugins.worklets()];
+
+// After
+import { worklets } from 'rollipop/plugins';
+plugins: [worklets()];
+```

--- a/docs/content/docs/features/reanimated-worklets.mdx
+++ b/docs/content/docs/features/reanimated-worklets.mdx
@@ -9,10 +9,11 @@ Rollipop includes a built-in worklet transformation plugin powered by Oxc. This 
 Add the `worklets()` plugin to your configuration:
 
 ```ts title="rollipop.config.ts"
-import { defineConfig, BuiltinPlugins } from 'rollipop';
+import { defineConfig } from 'rollipop';
+import { worklets } from 'rollipop/plugins';
 
 export default defineConfig({
-  plugins: [BuiltinPlugins.worklets()],
+  plugins: [worklets()],
 });
 ```
 

--- a/example/rollipop.config.ts
+++ b/example/rollipop.config.ts
@@ -1,11 +1,12 @@
 import { analyze } from '@rollipop/plugin-analyze';
 import { rozenite } from '@rollipop/plugin-rozenite';
-import { defineConfig, BuiltinPlugins, type PluginOption } from 'rollipop';
+import { defineConfig, type PluginOption } from 'rollipop';
+import { worklets } from 'rollipop/plugins';
 
 import { config, hot } from './plugins';
 
 function myPlugin(): PluginOption {
-  return [hot(), BuiltinPlugins.worklets(), config()];
+  return [hot(), worklets(), config()];
 }
 
 export default defineConfig({

--- a/packages/rollipop/package.json
+++ b/packages/rollipop/package.json
@@ -41,8 +41,14 @@
       "default": "./dist/pluginutils.js"
     },
     "./plugins": {
-      "types": "./dist/plugins.d.ts",
-      "default": "./dist/plugins.js"
+      "import": {
+        "types": "./dist/plugins.d.ts",
+        "default": "./dist/plugins.js"
+      },
+      "require": {
+        "types": "./dist/plugins.d.cts",
+        "default": "./dist/plugins.cjs"
+      }
     },
     "./runtime": {
       "import": {

--- a/packages/rollipop/package.json
+++ b/packages/rollipop/package.json
@@ -40,6 +40,10 @@
       "types": "./dist/pluginutils.d.ts",
       "default": "./dist/pluginutils.js"
     },
+    "./plugins": {
+      "types": "./dist/plugins.d.ts",
+      "default": "./dist/plugins.js"
+    },
     "./runtime": {
       "import": {
         "types": "./dist/runtime.d.ts",

--- a/packages/rollipop/src/index.ts
+++ b/packages/rollipop/src/index.ts
@@ -28,9 +28,6 @@ export * from './config';
 export type * from './types';
 export type * from './types/hmr';
 
-// Builtin plugins
-export * as BuiltinPlugins from './plugins';
-
 // CLI
 export * as cli from './node/cli';
 export * from './node/cli-utils';

--- a/packages/rollipop/vite.config.ts
+++ b/packages/rollipop/vite.config.ts
@@ -89,6 +89,13 @@ export default defineConfig({
       dts: true,
     },
     {
+      ...commonPackConfig,
+      entry: { plugins: 'src/plugins/index.ts' },
+      format: 'esm',
+      platform: 'node',
+      dts: true,
+    },
+    {
       ...runtimePackConfig,
       entry: 'src/runtime.ts',
       format: ['esm', 'cjs'],

--- a/packages/rollipop/vite.config.ts
+++ b/packages/rollipop/vite.config.ts
@@ -91,7 +91,7 @@ export default defineConfig({
     {
       ...commonPackConfig,
       entry: { plugins: 'src/plugins/index.ts' },
-      format: 'esm',
+      format: ['esm', 'cjs'],
       platform: 'node',
       dts: true,
     },


### PR DESCRIPTION
## Summary

Drops the `BuiltinPlugins` namespace on the main entry in favour of a dedicated `rollipop/plugins` sub-path. Builtin plugins are now imported by name, aligning with the existing `./commands` / `./pluginutils` / `./runtime` sub-paths and matching the Vite/Rollup ecosystem convention.

```ts
// before
import { BuiltinPlugins } from 'rollipop';
plugins: [BuiltinPlugins.worklets()];

// after
import { worklets } from 'rollipop/plugins';
plugins: [worklets()];
```

## Changes

- `packages/rollipop/vite.config.ts` — new pack entry using the `{ plugins: 'src/plugins/index.ts' }` object form. Object form is required because the default basename rule would emit `dist/index.js`, which collides with the main entry.
- `packages/rollipop/package.json` — adds the `./plugins` export pointing at `dist/plugins.{js,d.ts}`.
- `packages/rollipop/src/index.ts` — removes `export * as BuiltinPlugins from './plugins'`.
- `example/rollipop.config.ts` + `docs/content/docs/features/reanimated-worklets.mdx` — migrated to the new import form.
- `.changeset/plugins-subpath.md` — patch-level release note.

## Notes for reviewers

- Package is still `0.1.0-alpha.15`, so the `BuiltinPlugins` namespace is removed outright rather than kept as a compat alias. Only two call sites existed in the repo.
- The pre-existing `export * as plugins from './core/plugins'` on the main entry is unrelated (internal/advanced plugin exports) and left untouched by this PR. Its naming overlap with the new sub-path is worth a follow-up look.

## Test plan

- [x] `yarn lint` clean
- [x] `yarn typecheck:all` clean
- [x] `yarn build:all` — `dist/plugins.js` and `dist/plugins.d.ts` emit alongside the main entry
- [x] `yarn test:all` — 31 files / 195 tests pass locally
- [ ] CI green