### PR TITLE
fix(pkg): include src/runtime/hmr-client.ts in the published tarball

### DIFF
--- a/.changeset/hmr-client-files.md
+++ b/.changeset/hmr-client-files.md
@@ -1,0 +1,5 @@
+---
+"rollipop": patch
+---
+
+Include `src/runtime/hmr-client.ts` in the published tarball. The `./hmr-client` export maps to this raw TypeScript source, but the `files` field in `package.json` only listed `bin`, `dist`, and `client.d.ts` — so consumers hitting `import 'rollipop/hmr-client'` against a published version would fail to resolve the file.

--- a/packages/rollipop/package.json
+++ b/packages/rollipop/package.json
@@ -16,7 +16,8 @@
   "files": [
     "client.d.ts",
     "bin",
-    "dist"
+    "dist",
+    "src/runtime/hmr-client.ts"
   ],
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- \`./hmr-client\` export maps to the raw \`src/runtime/hmr-client.ts\`, but \`package.json#files\` only whitelisted \`bin\`, \`dist\`, and \`client.d.ts\`
- Consumers that imported \`rollipop/hmr-client\` against a published version resolved to a missing file
- Add \`src/runtime/hmr-client.ts\` to the \`files\` list so it ships with the tarball

## Test plan
- [x] \`yarn workspace rollipop pack --dry-run\` now lists \`src/runtime/hmr-client.ts\` alongside \`dist/hmr-runtime.iife.js\`