### PR TITLE
fix(test): align global identifier assertion with constant

### DIFF
--- a/packages/rollipop/e2e/server.spec.ts
+++ b/packages/rollipop/e2e/server.spec.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
 
 import { loadConfig } from '../src/config';
+import { GLOBAL_IDENTIFIER } from '../src/constants';
 import type { DevServer } from '../src/server/types';
 import { runServer } from '../src/utils/run-server';
 
@@ -87,8 +88,8 @@ describe('dev server', () => {
       expect(code).toContain('var __DEV__=true');
     });
 
-    it('contains __ROLLIPOP_GLOBAL__ definition', () => {
-      expect(code).toContain('__ROLLIPOP_GLOBAL__');
+    it('contains global identifier definition', () => {
+      expect(code).toContain(`var ${GLOBAL_IDENTIFIER}=typeof globalThis`);
     });
 
     it('contains __BUNDLE_START_TIME__ for performance tracking', () => {


### PR DESCRIPTION
## Summary

- The `contains __ROLLIPOP_GLOBAL__ definition` assertion in `packages/rollipop/e2e/server.spec.ts` broke after `4b8f4b2 fix: invalid global identifier` (#69 follow-up) renamed the prelude global to `_` (`packages/rollipop/src/constants.ts:GLOBAL_IDENTIFIER`).
- Updated the assertion to import `GLOBAL_IDENTIFIER` and check the actual prelude line (`var \${GLOBAL_IDENTIFIER}=typeof globalThis`), so it tracks the constant instead of a stale literal.

## Test plan

- [x] \`yarn workspace rollipop test\` — 32 files / 202 tests pass (was 1 failed before).
- [ ] CI green on this PR.