### PR TITLE
chore(deps): bump typescript to 6.0.3

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,5 @@
 catalog:
-  typescript: 5.9.3
+  typescript: 6.0.3
   vite-plus: latest
 
 catalogs:

--- a/example/__tests__/App.test.tsx
+++ b/example/__tests__/App.test.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 
-import App from '../App';
+import { App } from '../App';
 
 test('renders correctly', async () => {
   await ReactTestRenderer.act(() => {

--- a/example/package.json
+++ b/example/package.json
@@ -48,7 +48,7 @@
     "react-native-svg-transformer": "^1.5.3",
     "react-test-renderer": "19.2.3",
     "rollipop": "workspace:*",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=22.11.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
     "@types/node": "^24",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite-plus": "catalog:"
   },
   "packageManager": "yarn@4.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10062,7 +10062,7 @@ __metadata:
     react-native-worklets: "npm:^0.7.4"
     react-test-renderer: "npm:19.2.3"
     rollipop: "workspace:*"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -16117,7 +16117,7 @@ __metadata:
   dependencies:
     "@changesets/cli": "npm:^2.30.0"
     "@types/node": "npm:^24"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     vite-plus: "catalog:"
   languageName: unknown
   linkType: soft
@@ -17362,23 +17362,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.9.3, typescript@npm:^5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:6.0.3, typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumps TypeScript to `6.0.3` across the monorepo:
  - `.yarnrc.yml` catalog → `6.0.3`
  - root `package.json` direct dep → `^6.0.3`
  - `example/package.json` direct dep → `^6.0.3`
- Fixes a stale default-import in `example/__tests__/App.test.tsx` (`App` is a named export, not default) that was caught while verifying the example workspace under TS 6. The error is reproducible on TS 5.9.3 too — it had been silently ignored because `example` has no `typecheck` script.

## Test plan

- [x] `yarn typecheck:all` — clean across `rollipop`, `init`, `plugin-analyze`, `plugin-rozenite`, `docs`.
- [x] `yarn lint` — 0 warnings / 0 errors (171 files / 107 rules).
- [x] `yarn workspace rollipop test` — 32 files / 202 tests passing.
- [x] `tsc --noEmit` in `example/` — clean.
- [ ] CI green on this PR.