### PR TITLE
fix: bundle sourcemap output

### DIFF
--- a/.changeset/soft-maps-build.md
+++ b/.changeset/soft-maps-build.md
@@ -1,0 +1,5 @@
+---
+"rollipop": patch
+---
+
+enable sourcemap generation when bundle CLI receives `--sourcemap-output`

--- a/packages/rollipop/src/node/commands/bundle/__tests__/action.spec.ts
+++ b/packages/rollipop/src/node/commands/bundle/__tests__/action.spec.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+const rollipop = vi.hoisted(() => ({
+  loadConfig: vi.fn(),
+  resetCache: vi.fn(),
+  runBuild: vi.fn(),
+}));
+
+vi.mock('../../../../index', () => rollipop);
+
+import { action } from '../action';
+
+describe('bundle command action', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enables sourcemap generation when sourcemap-output is provided', async () => {
+    const config = { entry: 'index.js' };
+    rollipop.loadConfig.mockResolvedValue(config);
+    rollipop.runBuild.mockResolvedValue({});
+
+    await action.call(
+      { platforms: ['android', 'ios'] },
+      {
+        platform: 'android',
+        dev: false,
+        bundleOutput: 'dist/index.android.bundle',
+        sourcemapOutput: 'dist/index.android.bundle.map',
+        resetCache: false,
+        sourcemapUseAbsolutePath: false,
+        entryFile: 'index.js',
+      },
+    );
+
+    expect(rollipop.runBuild).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({
+        outfile: 'dist/index.android.bundle',
+        sourcemap: true,
+        sourcemapOutfile: 'dist/index.android.bundle.map',
+      }),
+    );
+  });
+
+  it('does not enable sourcemaps when sourcemap-output is omitted', async () => {
+    const config = { entry: 'index.js' };
+    rollipop.loadConfig.mockResolvedValue(config);
+    rollipop.runBuild.mockResolvedValue({});
+
+    await action.call(
+      { platforms: ['android', 'ios'] },
+      {
+        platform: 'android',
+        dev: false,
+        bundleOutput: 'dist/index.android.bundle',
+        resetCache: false,
+        sourcemapUseAbsolutePath: false,
+        entryFile: 'index.js',
+      },
+    );
+
+    const [, buildOptions] = rollipop.runBuild.mock.calls[0];
+    expect(buildOptions).not.toHaveProperty('sourcemap');
+    expect(buildOptions).toEqual(
+      expect.objectContaining({
+        outfile: 'dist/index.android.bundle',
+        sourcemapOutfile: undefined,
+      }),
+    );
+  });
+});

--- a/packages/rollipop/src/node/commands/bundle/action.ts
+++ b/packages/rollipop/src/node/commands/bundle/action.ts
@@ -30,6 +30,7 @@ export const action: CommandAction<BundleCommandArgs> = async function (options)
     dev: options.dev,
     minify: options.minify,
     cache: options.cache,
+    ...(options.sourcemapOutput ? { sourcemap: true } : {}),
     outfile: options.bundleOutput,
     sourcemapOutfile: options.sourcemapOutput,
     assetsDir: options.assetsDest,


### PR DESCRIPTION
## Summary

- Enable sourcemap generation when the `bundle` CLI receives `--sourcemap-output`
- Add coverage for the bundle command action so the CLI forwards `sourcemap: true` only when a sourcemap output path is provided
- Add a patch changeset for `rollipop`

## Root Cause

React Native Gradle already passes a sourcemap output path to the JavaScript bundler. The missing piece was inside Rollipop: the parsed `--sourcemap-output` value was forwarded as `sourcemapOutfile`, but it was not also treated as a request to generate sourcemaps.

### End-to-end flow

1. React Native Gradle registers a bundle task for non-debuggable variants.

   `TaskConfiguration.kt` registers `createBundle${targetName}JsAndAssets` as a `BundleHermesCTask`.

   For a normal Android release variant, that becomes:

   ```text
   :app:createBundleReleaseJsAndAssets
   ```

2. `BundleHermesCTask.run()` computes the JavaScript bundle output and packager sourcemap output.

   In Hermes builds, the first sourcemap expected from the JS bundler is the packager sourcemap:

   ```text
   android/app/build/intermediates/sourcemaps/react/release/index.android.bundle.packager.map
   ```

3. `BundleHermesCTask.getBundleCommand()` builds the React Native CLI command and includes `--sourcemap-output`.

   The relevant arguments are assembled like this:

   ```text
   node
   <react-native>/cli.js
   bundle
   --platform android
   --dev false
   --reset-cache
   --entry-file <app>/index.js
   --bundle-output <app>/android/app/build/generated/assets/react/release/index.android.bundle
   --assets-dest <app>/android/app/build/generated/res/react/release
   --sourcemap-output <app>/android/app/build/intermediates/sourcemaps/react/release/index.android.bundle.packager.map
   --minify false
   --verbose
   ```

4. Gradle executes that exact command with `execOperations.exec { exec.commandLine(command) }`.

   So by the time the JS CLI starts, the sourcemap output path is already present in argv. This is not a Gradle configuration issue.

5. Apps can replace React Native CLI commands via `react-native.config.js`.

   A Rollipop app typically exposes:

   ```js
   module.exports = {
     commands: require('rollipop/commands'),
   };
   ```

   That means React Native CLI dispatches the `bundle` command to Rollipop's React Native CLI command wrapper.

6. Rollipop defines and parses `--sourcemap-output <string>` as `options.sourcemapOutput`.

   Before this change, the Rollipop bundle action passed that value only as:

   ```ts
   sourcemapOutfile: options.sourcemapOutput,
   ```

   It did not pass:

   ```ts
   sourcemap: true,
   ```

7. `Bundler.build()` later decides the final Rolldown sourcemap option from `resolvedBuildOptions.sourcemap`.

   Existing code normalizes it to a boolean:

   ```ts
   const sourcemap = resolvedBuildOptions.sourcemap ? true : false;
   ```

   With `--sourcemap-output` alone, `resolvedBuildOptions.sourcemap` is `undefined`, so Rollipop sends `output.sourcemap = false` to Rolldown.

8. Because Rolldown receives `sourcemap: false`, it does not emit a `.map` file and the output chunk has no `sourcemapFileName`.

   Rollipop has later code that can move the generated map to `sourcemapOutfile`, but that branch requires `chunk.sourcemapFileName`. Since no map was generated, there is nothing to move.

9. In Hermes builds, React Native Gradle then tries to compose the packager sourcemap with the Hermes compiler sourcemap.

   The expected packager file is missing:

   ```text
   android/app/build/intermediates/sourcemaps/react/release/index.android.bundle.packager.map
   ```

   Therefore the final composed sourcemap cannot be produced correctly:

   ```text
   android/app/build/generated/sourcemaps/react/release/index.android.bundle.map
   ```

## Fix

When `options.sourcemapOutput` is present, the bundle action now forwards `sourcemap: true` to `runBuild`:

```ts
...(options.sourcemapOutput ? { sourcemap: true } : {}),
```

This keeps the existing behavior when `--sourcemap-output` is omitted, while matching React Native CLI semantics: providing a sourcemap output path means the bundler should generate a sourcemap at that path.

## Validation

- `yarn workspace rollipop vp test --run src/node/commands/bundle/__tests__/action.spec.ts`
- `yarn workspace rollipop typecheck`
- `yarn fmt`
